### PR TITLE
feat(briefcase): scaffold Phase 1 — CMD/PRJ/QRY trinity + plan

### DIFF
--- a/apps/guide_briefcase_lifecycle/include/briefcase_state.hrl
+++ b/apps/guide_briefcase_lifecycle/include/briefcase_state.hrl
@@ -1,0 +1,19 @@
+%%% @doc State record for a single briefcase-file aggregate.
+%%%
+%%% Stream id convention: `<<"briefcase-", FileId/binary>>`.
+%%% Status is an integer treated as bit flags — see briefcase_status.hrl.
+%%% @end
+
+-record(briefcase_state, {
+    file_id       :: binary() | undefined,
+    realm         :: binary() | undefined,
+    path          :: binary() | undefined,   %% current path in the virtual tree
+    mime_type     :: binary() | undefined,
+    size          :: non_neg_integer() | undefined,
+    content_hash  :: binary() | undefined,   %% BLAKE3 of plaintext
+    chunk_hashes  :: [binary()],             %% BLAKE3 per chunk (empty in v1 whole-file)
+    author_did    :: binary() | undefined,
+    status        :: non_neg_integer(),      %% bit flags
+    uploaded_at   :: integer() | undefined,
+    revised_at    :: integer() | undefined
+}).

--- a/apps/guide_briefcase_lifecycle/include/briefcase_status.hrl
+++ b/apps/guide_briefcase_lifecycle/include/briefcase_status.hrl
@@ -1,0 +1,12 @@
+%%% @doc Bit flags for briefcase file lifecycle status.
+%%%
+%%% Use with evoq_bit_flags for status manipulation.
+%%% Powers of two — each flag gets a unique bit position.
+%%% @end
+
+-define(FILE_UPLOADED,  1).   %% 2^0
+-define(FILE_REVISED,   2).   %% 2^1
+-define(FILE_MOVED,     4).   %% 2^2
+-define(FILE_ARCHIVED,  8).   %% 2^3  (soft delete, recoverable)
+-define(FILE_PURGED,   16).   %% 2^4  (hard delete, chunks GCable)
+-define(FILE_SHARED,   32).   %% 2^5  (at least one access grant active)

--- a/apps/guide_briefcase_lifecycle/src/briefcase_aggregate.erl
+++ b/apps/guide_briefcase_lifecycle/src/briefcase_aggregate.erl
@@ -1,0 +1,52 @@
+%%% @doc Aggregate for briefcase file lifecycle.
+%%%
+%%% One aggregate per file. Stream: `briefcase-{file_id}`.
+%%% file_id is a BLAKE3 of (realm || path || author_did || wallclock_ms)
+%%% generated at upload time.
+%%% @end
+-module(briefcase_aggregate).
+-behaviour(evoq_aggregate).
+
+-include("briefcase_state.hrl").
+-include("briefcase_status.hrl").
+
+-export([init/1, execute/2, apply/2]).
+-export([state_module/0, stream_id/1]).
+
+-spec state_module() -> module().
+state_module() -> briefcase_state.
+
+%% ===================================================================
+%% Evoq callbacks
+%% ===================================================================
+
+init(AggregateId) ->
+    {ok, briefcase_state:new(AggregateId)}.
+
+%% @doc Build stream id from file_id.
+-spec stream_id(binary()) -> binary().
+stream_id(FileId) when is_binary(FileId) ->
+    <<"briefcase-", FileId/binary>>.
+
+%% @doc Execute command — State FIRST (evoq convention).
+execute(State, #{command_type := CmdType} = Payload) ->
+    do_execute(CmdType, State, Payload);
+execute(_State, _Unknown) ->
+    {error, unknown_command}.
+
+%% @doc Evoq callback: apply/2 — State FIRST. Delegates to state module.
+apply(State, Event) ->
+    briefcase_state:apply_event(State, Event).
+
+%% ===================================================================
+%% Command routing
+%% ===================================================================
+
+do_execute(upload_file, State, Payload) ->
+    case State#briefcase_state.status band ?FILE_UPLOADED of
+        0 -> maybe_upload_file:handle_from_map(Payload);
+        _ -> {error, already_uploaded}
+    end;
+
+do_execute(_Unknown, _State, _Payload) ->
+    {error, unknown_command}.

--- a/apps/guide_briefcase_lifecycle/src/briefcase_state.erl
+++ b/apps/guide_briefcase_lifecycle/src/briefcase_state.erl
@@ -1,0 +1,83 @@
+%%% @doc State module for briefcase file aggregate.
+%%%
+%%% Owns the state record, event folding, and serialization. One
+%%% aggregate instance per file — stream id is `briefcase-{file_id}`.
+%%% @end
+-module(briefcase_state).
+
+-behaviour(evoq_state).
+
+-include("briefcase_state.hrl").
+-include("briefcase_status.hrl").
+
+-export([new/1, apply_event/2, to_map/1]).
+
+-type state() :: #briefcase_state{}.
+-export_type([state/0]).
+
+%% @doc Create initial empty state for a given aggregate id (file_id).
+-spec new(binary()) -> state().
+new(FileId) ->
+    #briefcase_state{
+        file_id      = FileId,
+        chunk_hashes = [],
+        status       = 0
+    }.
+
+%% @doc Apply event to state. State FIRST, Event SECOND.
+-spec apply_event(state(), map()) -> state().
+apply_event(State, #{event_type := EventType} = Event) ->
+    do_apply(EventType, State, Event);
+apply_event(State, _) ->
+    State.
+
+%% @doc Serialize state to map.
+-spec to_map(state()) -> map().
+to_map(#briefcase_state{} = S) ->
+    #{
+        file_id      => S#briefcase_state.file_id,
+        realm        => S#briefcase_state.realm,
+        path         => S#briefcase_state.path,
+        mime_type    => S#briefcase_state.mime_type,
+        size         => S#briefcase_state.size,
+        content_hash => S#briefcase_state.content_hash,
+        chunk_hashes => S#briefcase_state.chunk_hashes,
+        author_did   => S#briefcase_state.author_did,
+        status       => S#briefcase_state.status,
+        uploaded_at  => S#briefcase_state.uploaded_at,
+        revised_at   => S#briefcase_state.revised_at
+    }.
+
+%% ===================================================================
+%% Event folding
+%% ===================================================================
+
+do_apply(<<"file_uploaded_v1">>, State, #{data := Data}) ->
+    apply_file_uploaded(State, Data);
+do_apply(<<"file_uploaded_v1">>, State, Data) ->
+    %% Event without wrapper
+    apply_file_uploaded(State, Data);
+do_apply(_UnknownEventType, State, _Event) ->
+    State.
+
+apply_file_uploaded(State, Data) ->
+    State#briefcase_state{
+        realm        = gf(realm, Data, State#briefcase_state.realm),
+        path         = gf(path, Data, State#briefcase_state.path),
+        mime_type    = gf(mime_type, Data, State#briefcase_state.mime_type),
+        size         = gf(size, Data, State#briefcase_state.size),
+        content_hash = gf(content_hash, Data, State#briefcase_state.content_hash),
+        chunk_hashes = gf(chunk_hashes, Data, State#briefcase_state.chunk_hashes),
+        author_did   = gf(author_did, Data, State#briefcase_state.author_did),
+        uploaded_at  = gf(uploaded_at, Data, State#briefcase_state.uploaded_at),
+        status       = evoq_bit_flags:set(State#briefcase_state.status, ?FILE_UPLOADED)
+    }.
+
+%% @private Get field from map with default (atom or binary key).
+gf(Key, Map, Default) when is_atom(Key) ->
+    case maps:find(Key, Map) of
+        {ok, V} -> V;
+        error ->
+            BinKey = atom_to_binary(Key, utf8),
+            maps:get(BinKey, Map, Default)
+    end.

--- a/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src
+++ b/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src
@@ -1,0 +1,17 @@
+{application, guide_briefcase_lifecycle, [
+    {description, "CMD service for briefcase file lifecycle: upload, revise, move, archive, purge, grant, revoke"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {mod, {guide_briefcase_lifecycle_app, []}},
+    {applications, [
+        kernel,
+        stdlib,
+        reckon_db,
+        evoq,
+        reckon_evoq
+    ]},
+    {env, []},
+    {modules, []},
+    {licenses, ["Apache-2.0"]},
+    {links, [{"GitHub", "https://github.com/hecate-social/hecate-daemon"}]}
+]}.

--- a/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle_app.erl
+++ b/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle_app.erl
@@ -1,0 +1,11 @@
+%%% @doc OTP application module for guide_briefcase_lifecycle.
+-module(guide_briefcase_lifecycle_app).
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    guide_briefcase_lifecycle_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle_sup.erl
+++ b/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle_sup.erl
@@ -1,0 +1,24 @@
+%%% @doc Top-level supervisor for guide_briefcase_lifecycle.
+%%%
+%%% Phase 1: no child processes — commands dispatch stateless through
+%%% `reckon_evoq_adapter`. Later phases add:
+%%%   - `briefcase_chunk_store` — content-addressed chunk I/O
+%%%   - `briefcase_fs_watcher`  — reconciler (Phase 6)
+%%%   - `briefcase_mesh_emitter` — pubsub event broadcast (Phase 2)
+%%% @end
+-module(guide_briefcase_lifecycle_sup).
+-behaviour(supervisor).
+
+-export([start_link/0, init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{
+        strategy  => one_for_one,
+        intensity => 10,
+        period    => 10
+    },
+    Children = [],
+    {ok, {SupFlags, Children}}.

--- a/apps/guide_briefcase_lifecycle/src/upload_file/file_uploaded_v1.erl
+++ b/apps/guide_briefcase_lifecycle/src/upload_file/file_uploaded_v1.erl
@@ -1,0 +1,75 @@
+%%% @doc file_uploaded_v1 event.
+%%%
+%%% Emitted on first appearance of a file in the briefcase.
+%%% Subsequent modifications emit `file_revised_v{N}` (future phase).
+%%% @end
+-module(file_uploaded_v1).
+-behaviour(evoq_event).
+
+-export([new/1, new/8, to_map/1, from_map/1]).
+-export([event_type/0]).
+
+-record(file_uploaded_v1, {
+    file_id      :: binary(),
+    realm        :: binary(),
+    path         :: binary(),
+    mime_type    :: binary(),
+    size         :: non_neg_integer(),
+    content_hash :: binary(),
+    author_did   :: binary(),
+    uploaded_at  :: integer()
+}).
+
+-opaque file_uploaded_v1() :: #file_uploaded_v1{}.
+-export_type([file_uploaded_v1/0]).
+
+event_type() -> <<"file_uploaded_v1">>.
+
+-spec new(map()) -> file_uploaded_v1().
+new(#{file_id := FileId, realm := Realm, path := Path,
+      mime_type := Mime, size := Size, content_hash := Hash,
+      author_did := Did, uploaded_at := UploadedAt}) ->
+    new(FileId, Realm, Path, Mime, Size, Hash, Did, UploadedAt).
+
+-spec new(binary(), binary(), binary(), binary(), non_neg_integer(),
+          binary(), binary(), integer()) -> file_uploaded_v1().
+new(FileId, Realm, Path, Mime, Size, Hash, Did, UploadedAt) ->
+    #file_uploaded_v1{
+        file_id      = FileId,
+        realm        = Realm,
+        path         = Path,
+        mime_type    = Mime,
+        size         = Size,
+        content_hash = Hash,
+        author_did   = Did,
+        uploaded_at  = UploadedAt
+    }.
+
+-spec to_map(file_uploaded_v1()) -> map().
+to_map(#file_uploaded_v1{
+    file_id = FileId, realm = Realm, path = Path, mime_type = Mime,
+    size = Size, content_hash = Hash, author_did = Did,
+    uploaded_at = UploadedAt}) ->
+    #{
+        event_type   => <<"file_uploaded_v1">>,
+        file_id      => FileId,
+        realm        => Realm,
+        path         => Path,
+        mime_type    => Mime,
+        size         => Size,
+        content_hash => Hash,
+        author_did   => Did,
+        uploaded_at  => UploadedAt
+    }.
+
+-spec from_map(map()) -> {ok, file_uploaded_v1()} | {error, term()}.
+from_map(#{file_id := FileId, realm := Realm, path := Path,
+           mime_type := Mime, size := Size, content_hash := Hash,
+           author_did := Did, uploaded_at := UploadedAt}) ->
+    {ok, #file_uploaded_v1{
+        file_id = FileId, realm = Realm, path = Path, mime_type = Mime,
+        size = Size, content_hash = Hash, author_did = Did,
+        uploaded_at = UploadedAt
+    }};
+from_map(_) ->
+    {error, invalid_file_uploaded_event}.

--- a/apps/guide_briefcase_lifecycle/src/upload_file/maybe_upload_file.erl
+++ b/apps/guide_briefcase_lifecycle/src/upload_file/maybe_upload_file.erl
@@ -1,0 +1,74 @@
+%%% @doc Handler for upload_file command.
+%%%
+%%% Validates payload, emits `file_uploaded_v1`. Chunk storage +
+%%% mesh emission are added in Phase 2+.
+%%% @end
+-module(maybe_upload_file).
+
+-export([handle/1, handle_from_map/1, dispatch/1]).
+
+-dialyzer({nowarn_function, [dispatch/1]}).
+-dialyzer({nowarn_function, [handle/1]}).
+
+-include_lib("evoq/include/evoq.hrl").
+
+-spec handle_from_map(map()) -> {ok, [map()]} | {error, term()}.
+handle_from_map(#{file_id := FileId, realm := Realm, path := Path,
+                  mime_type := Mime, size := Size, content_hash := Hash,
+                  author_did := Did} = Payload) ->
+    UploadedAt = maps:get(uploaded_at, Payload,
+                          erlang:system_time(millisecond)),
+    Cmd = upload_file_v1:new(FileId, Realm, Path, Mime, Size, Hash,
+                             Did, UploadedAt),
+    handle(Cmd);
+handle_from_map(_) ->
+    {error, missing_fields}.
+
+-spec handle(upload_file_v1:upload_file_v1()) ->
+    {ok, [map()]} | {error, term()}.
+handle(Command) ->
+    Map = upload_file_v1:to_map(Command),
+    case validate(Map) of
+        ok ->
+            #{file_id := FileId, realm := Realm, path := Path,
+              mime_type := Mime, size := Size, content_hash := Hash,
+              author_did := Did, uploaded_at := UploadedAt} = Map,
+            Event = file_uploaded_v1:new(FileId, Realm, Path, Mime,
+                                         Size, Hash, Did, UploadedAt),
+            {ok, [file_uploaded_v1:to_map(Event)]};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec dispatch(upload_file_v1:upload_file_v1()) ->
+    {ok, non_neg_integer(), [map()]} | {error, term()}.
+dispatch(Cmd) ->
+    FileId = upload_file_v1:get_file_id(Cmd),
+    StreamId = briefcase_aggregate:stream_id(FileId),
+    CmdMap = upload_file_v1:to_map(Cmd),
+    EvoqCmd = #evoq_command{
+        command_type   = upload_file,
+        aggregate_type = briefcase_aggregate,
+        aggregate_id   = StreamId,
+        payload        = CmdMap#{command_type => upload_file},
+        metadata       = #{timestamp => erlang:system_time(millisecond)}
+    },
+    evoq_dispatcher:dispatch(EvoqCmd, #{
+        store_id    => briefcase_store,
+        adapter     => reckon_evoq_adapter,
+        consistency => eventual
+    }).
+
+%% Internal
+
+validate(#{realm := R, path := P, content_hash := H, author_did := D, size := Sz}) ->
+    case {byte_size(R), byte_size(P), byte_size(H), byte_size(D), Sz} of
+        {0, _, _, _, _} -> {error, realm_required};
+        {_, 0, _, _, _} -> {error, path_required};
+        {_, _, 0, _, _} -> {error, content_hash_required};
+        {_, _, _, 0, _} -> {error, author_did_required};
+        {_, _, _, _, S} when S < 0 -> {error, invalid_size};
+        _ -> ok
+    end;
+validate(_) ->
+    {error, missing_fields}.

--- a/apps/guide_briefcase_lifecycle/src/upload_file/upload_file_v1.erl
+++ b/apps/guide_briefcase_lifecycle/src/upload_file/upload_file_v1.erl
@@ -1,0 +1,87 @@
+%%% @doc upload_file_v1 command.
+%%%
+%%% First appearance of a file in the briefcase. Subsequent modifications
+%%% use `revise_file_v{N}` (not in Phase 1 scaffold).
+%%% @end
+-module(upload_file_v1).
+-behaviour(evoq_command).
+
+-export([new/1, new/8, to_map/1, from_map/1]).
+-export([command_type/0]).
+-export([get_file_id/1, get_realm/1, get_path/1, get_mime_type/1,
+         get_size/1, get_content_hash/1, get_author_did/1, get_uploaded_at/1]).
+
+-record(upload_file_v1, {
+    file_id      :: binary(),
+    realm        :: binary(),
+    path         :: binary(),
+    mime_type    :: binary(),
+    size         :: non_neg_integer(),
+    content_hash :: binary(),
+    author_did   :: binary(),
+    uploaded_at  :: integer()
+}).
+
+-opaque upload_file_v1() :: #upload_file_v1{}.
+-export_type([upload_file_v1/0]).
+
+command_type() -> upload_file_v1.
+
+-spec new(map()) -> {ok, upload_file_v1()} | {error, missing_fields}.
+new(#{file_id := FileId, realm := Realm, path := Path,
+      mime_type := Mime, size := Size, content_hash := Hash,
+      author_did := Did, uploaded_at := UploadedAt}) ->
+    {ok, new(FileId, Realm, Path, Mime, Size, Hash, Did, UploadedAt)};
+new(_) ->
+    {error, missing_fields}.
+
+-spec new(binary(), binary(), binary(), binary(), non_neg_integer(),
+          binary(), binary(), integer()) -> upload_file_v1().
+new(FileId, Realm, Path, Mime, Size, Hash, Did, UploadedAt) ->
+    #upload_file_v1{
+        file_id      = FileId,
+        realm        = Realm,
+        path         = Path,
+        mime_type    = Mime,
+        size         = Size,
+        content_hash = Hash,
+        author_did   = Did,
+        uploaded_at  = UploadedAt
+    }.
+
+-spec to_map(upload_file_v1()) -> map().
+to_map(#upload_file_v1{
+    file_id = FileId, realm = Realm, path = Path, mime_type = Mime,
+    size = Size, content_hash = Hash, author_did = Did,
+    uploaded_at = UploadedAt}) ->
+    #{
+        file_id      => FileId,
+        realm        => Realm,
+        path         => Path,
+        mime_type    => Mime,
+        size         => Size,
+        content_hash => Hash,
+        author_did   => Did,
+        uploaded_at  => UploadedAt
+    }.
+
+-spec from_map(map()) -> {ok, upload_file_v1()} | {error, term()}.
+from_map(#{file_id := FileId, realm := Realm, path := Path,
+           mime_type := Mime, size := Size, content_hash := Hash,
+           author_did := Did, uploaded_at := UploadedAt}) ->
+    {ok, #upload_file_v1{
+        file_id = FileId, realm = Realm, path = Path, mime_type = Mime,
+        size = Size, content_hash = Hash, author_did = Did,
+        uploaded_at = UploadedAt
+    }};
+from_map(_) ->
+    {error, invalid_upload_file_command}.
+
+get_file_id(#upload_file_v1{file_id = V}) -> V.
+get_realm(#upload_file_v1{realm = V}) -> V.
+get_path(#upload_file_v1{path = V}) -> V.
+get_mime_type(#upload_file_v1{mime_type = V}) -> V.
+get_size(#upload_file_v1{size = V}) -> V.
+get_content_hash(#upload_file_v1{content_hash = V}) -> V.
+get_author_did(#upload_file_v1{author_did = V}) -> V.
+get_uploaded_at(#upload_file_v1{uploaded_at = V}) -> V.

--- a/apps/project_briefcase_files/src/briefcase_lifecycle_to_files.erl
+++ b/apps/project_briefcase_files/src/briefcase_lifecycle_to_files.erl
@@ -1,0 +1,63 @@
+%%% @doc Merged projection: briefcase lifecycle events -> files ETS.
+%%%
+%%% Phase 1 handles `file_uploaded_v1` only. Later phases add
+%%% `file_revised_v1`, `file_moved_v1`, `file_archived_v1`,
+%%% `file_purged_v1`, `folder_opened_v1`, `folder_collapsed_v1`,
+%%% `access_granted_v1`, `access_revoked_v1`, chunk transfer events.
+%%% @end
+-module(briefcase_lifecycle_to_files).
+-behaviour(evoq_projection).
+
+-export([interested_in/0, init/1, project/4]).
+
+-define(TABLE, briefcase_files).
+
+interested_in() ->
+    [<<"file_uploaded_v1">>].
+
+init(_Config) ->
+    {ok, RM} = evoq_read_model:new(evoq_read_model_ets, #{name => ?TABLE}),
+    {ok, #{}, RM}.
+
+project(#{data := Data} = Event, _Metadata, State, RM) ->
+    case get_event_type(Event) of
+        <<"file_uploaded_v1">> -> project_file_uploaded(Data, State, RM);
+        _                      -> {ok, State, RM}
+    end.
+
+%% ===================================================================
+%% file_uploaded_v1 — insert new file into read model
+%% ===================================================================
+
+project_file_uploaded(Data, State, RM) ->
+    FileId = gf(file_id, Data),
+    Entry = #{
+        file_id      => FileId,
+        realm        => gf(realm, Data),
+        path         => gf(path, Data),
+        mime_type    => gf(mime_type, Data),
+        size         => gf(size, Data),
+        content_hash => gf(content_hash, Data),
+        author_did   => gf(author_did, Data),
+        uploaded_at  => gf(uploaded_at, Data),
+        status       => 1,
+        status_label => <<"Uploaded">>
+    },
+    {ok, RM2} = evoq_read_model:put(RM, FileId, Entry),
+    {ok, State, RM2}.
+
+%% ===================================================================
+%% Helpers
+%% ===================================================================
+
+get_event_type(#{event_type := T}) -> T;
+get_event_type(#{<<"event_type">> := T}) -> T;
+get_event_type(_) -> undefined.
+
+gf(Key, Map) when is_atom(Key) ->
+    case maps:find(Key, Map) of
+        {ok, V} -> V;
+        error ->
+            BinKey = atom_to_binary(Key, utf8),
+            maps:get(BinKey, Map, undefined)
+    end.

--- a/apps/project_briefcase_files/src/project_briefcase_files.app.src
+++ b/apps/project_briefcase_files/src/project_briefcase_files.app.src
@@ -1,0 +1,16 @@
+{application, project_briefcase_files, [
+    {description, "PRJ service: briefcase lifecycle events -> files read model"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {mod, {project_briefcase_files_app, []}},
+    {applications, [
+        kernel,
+        stdlib,
+        evoq,
+        guide_briefcase_lifecycle
+    ]},
+    {env, []},
+    {modules, []},
+    {licenses, ["Apache-2.0"]},
+    {links, [{"GitHub", "https://github.com/hecate-social/hecate-daemon"}]}
+]}.

--- a/apps/project_briefcase_files/src/project_briefcase_files_app.erl
+++ b/apps/project_briefcase_files/src/project_briefcase_files_app.erl
@@ -1,0 +1,11 @@
+%%% @doc OTP application module for project_briefcase_files.
+-module(project_briefcase_files_app).
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    project_briefcase_files_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/apps/project_briefcase_files/src/project_briefcase_files_sup.erl
+++ b/apps/project_briefcase_files/src/project_briefcase_files_sup.erl
@@ -1,0 +1,22 @@
+%%% @doc Supervisor for project_briefcase_files.
+%%%
+%%% Phase 1: no children yet — the projection is registered with evoq
+%%% at boot by `hecate_app`. Later phases may add a dedicated store
+%%% worker or read-model cache.
+%%% @end
+-module(project_briefcase_files_sup).
+-behaviour(supervisor).
+
+-export([start_link/0, init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{
+        strategy  => one_for_one,
+        intensity => 10,
+        period    => 10
+    },
+    Children = [],
+    {ok, {SupFlags, Children}}.

--- a/apps/query_briefcase_files/src/get_files_page/get_files_page_api.erl
+++ b/apps/query_briefcase_files/src/get_files_page/get_files_page_api.erl
@@ -1,0 +1,39 @@
+%%% @doc API handler: GET /api/briefcase/files
+%%%
+%%% Returns all known files in the briefcase read model. Later phases
+%%% add pagination, realm/path filtering, sort options.
+%%% @end
+-module(get_files_page_api).
+
+-export([init/2, routes/0]).
+
+-ifdef(TEST).
+-compile(export_all).
+-compile(nowarn_export_all).
+-endif.
+
+routes() -> [{"/api/briefcase/files", ?MODULE, []}].
+
+init(Req0, State) ->
+    case cowboy_req:method(Req0) of
+        <<"GET">> -> handle_get(Req0, State);
+        _         -> hecate_api_utils:method_not_allowed(Req0)
+    end.
+
+handle_get(Req0, _State) ->
+    case list_active() of
+        {ok, Files} ->
+            hecate_api_utils:json_ok(#{items => Files}, Req0);
+        {error, Reason} ->
+            hecate_api_utils:json_error(500, Reason, Req0)
+    end.
+
+%% Phase 1: read directly from the briefcase_files ETS table.
+%% Phase 2+: add a dedicated store module (project_briefcase_files_store).
+list_active() ->
+    try
+        Entries = [V || {_K, V} <- ets:tab2list(briefcase_files)],
+        {ok, Entries}
+    catch
+        error:badarg -> {ok, []}
+    end.

--- a/apps/query_briefcase_files/src/query_briefcase_files.app.src
+++ b/apps/query_briefcase_files/src/query_briefcase_files.app.src
@@ -1,0 +1,15 @@
+{application, query_briefcase_files, [
+    {description, "Briefcase files query service (read models)"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {mod, {query_briefcase_files_app, []}},
+    {applications, [
+        kernel,
+        stdlib,
+        project_briefcase_files
+    ]},
+    {env, []},
+    {modules, []},
+    {licenses, ["Apache-2.0"]},
+    {links, [{"GitHub", "https://github.com/hecate-social/hecate-daemon"}]}
+]}.

--- a/apps/query_briefcase_files/src/query_briefcase_files_app.erl
+++ b/apps/query_briefcase_files/src/query_briefcase_files_app.erl
@@ -1,0 +1,11 @@
+%%% @doc OTP application module for query_briefcase_files.
+-module(query_briefcase_files_app).
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    query_briefcase_files_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/apps/query_briefcase_files/src/query_briefcase_files_sup.erl
+++ b/apps/query_briefcase_files/src/query_briefcase_files_sup.erl
@@ -1,0 +1,21 @@
+%%% @doc Supervisor for query_briefcase_files.
+%%%
+%%% Phase 1: no children. Read endpoints are registered with the HTTP
+%%% router (`hecate_api`) at daemon boot.
+%%% @end
+-module(query_briefcase_files_sup).
+-behaviour(supervisor).
+
+-export([start_link/0, init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{
+        strategy  => one_for_one,
+        intensity => 10,
+        period    => 10
+    },
+    Children = [],
+    {ok, {SupFlags, Children}}.

--- a/plans/PLAN_BRIEFCASE.md
+++ b/plans/PLAN_BRIEFCASE.md
@@ -1,0 +1,243 @@
+# Plan: Hecate Briefcase — Mesh-Backed File Sharing
+
+**Status:** Planning (Phase 0 → Phase 1 scaffold shipped with this PR)
+**Created:** 2026-04-20
+**Last Updated:** 2026-04-20
+
+---
+
+## Overview
+
+Hecate Briefcase is the **built-in file-sharing capability** of the Hecate
+daemon: a decentralized, end-to-end-encrypted, realm-scoped file store with
+an "appears everywhere in the realm" UX. It is the **killer app** that
+demonstrates Macula's DHT PubSub/RPC primitives doing real work.
+
+Positioned as a Dropbox/Nextcloud replacement that:
+
+- Stores files across realm peers — no central server
+- E2E encrypted — the daemon on any peer cannot read foreign content
+- Works across home-ISP NATs without port forwarding (QUIC)
+- Offline-first; local queue reconciles on reconnect
+- Crosses the rebel → SMB audience chasm
+
+**Other Hecate apps (scribe, ledger, stage) consume Briefcase** as their
+document storage layer. Briefcase is a capability, not a use case.
+
+---
+
+## Positioning Decision
+
+**Briefcase is built into `hecate-daemon`, not a plugin.**
+
+Reasons:
+
+1. Briefcase is foundational infrastructure — peer to `settings`, `plugins`,
+   `realm_memberships`. Not a third-party use-case like `trader` or `martha`.
+2. Document apps (scribe, ledger, stage) depend on it. Core capabilities
+   don't live in the plugin layer.
+3. Storage + crypto + mesh integration operates at the daemon's trust level.
+
+The prior `hecate-apps/hecate-app-briefcase` placeholder repo has been
+deleted (was empty scaffold; capability belongs inside the daemon).
+
+---
+
+## Architecture
+
+Three apps following the CMD / PRJ / QRY trinity pattern used across the
+rest of `hecate-daemon`:
+
+| App | Department | Purpose |
+|---|---|---|
+| `guide_briefcase_lifecycle` | CMD | Commands, events, aggregate, chunk store, crypto, mesh emitters |
+| `project_briefcase_files` | PRJ | Event-to-read-model projections (file tree + chunk index) |
+| `query_briefcase_files` | QRY | HTTP API — `GET /api/briefcase/...` |
+
+### Mesh primitives used
+
+- **PubSub** topic `briefcase/realm/{realm}/events` — event log broadcast
+- **RPC** procedures `briefcase.get_chunk`, `briefcase.has_chunk`,
+  `briefcase.list_chunks`
+- **DHT** — chunk-to-peer location hints
+- **Realm** — trust boundary
+- **UCAN / DID** — capability grants for cross-realm sharing
+- **QUIC** — NAT traversal built-in
+
+### Storage
+
+- **Event log**: ReckonDB stream `briefcase-{realm}`
+- **Read model**: SQLite, projected from events
+- **Chunks**: content-addressed on disk,
+  `$HECATE_HOME/briefcase/chunks/{blake3[:2]}/{blake3}.enc`
+
+---
+
+## Key Technical Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Content hashing | BLAKE3 | Already in stack via `macula_blake3_nif`; fast, tree-hashable |
+| Chunk size (v1) | Fixed 1 MiB | Simple; FastCDC later |
+| Encryption | XChaCha20-Poly1305 per chunk | AEAD, no nonce-reuse footguns |
+| Key derivation | HKDF-SHA256; per-realm master → per-file key | Lazy rotation, capability-friendly |
+| Signatures | Ed25519 via existing DID keys | Already in stack |
+| Conflict resolution (v1) | LWW with wallclock + peer-id tiebreaker | Ship fast; upgrade to CRDT if needed |
+| Replication (v1) | Full within realm | Predictable; erasure coding is Phase 5 |
+| Transport | Mesh RPC (QUIC under hood) | NAT traversal included |
+| Local truth model (v1) | API-only; no sync folder | No reconciler complexity upfront |
+| Local truth model (v6) | Event-sourced with FS reconciler | Dropbox-style UX once correctness is solid |
+
+---
+
+## Event Vocabulary
+
+All business-verb past-tense, following project naming conventions (no
+CRUD verbs):
+
+- `file_uploaded` — first appearance
+- `file_revised` — new version (not "updated")
+- `file_moved` — path change
+- `file_archived` — soft delete, tombstone, recoverable
+- `file_purged` — hard delete, chunks GCable
+- `folder_opened` — folder created
+- `folder_collapsed` — folder removed
+- `access_granted` — UCAN issued for subject DID
+- `access_revoked`
+- `chunk_transfer_started` / `_completed` / `_cancelled`
+- `chunk_landed` — a peer acquired a chunk (DHT hint)
+
+Every event carries: `realm`, `subject_did`, `wallclock`, `vector_clock`,
+`parent_event_id`.
+
+---
+
+## RPC Surface (v1)
+
+```
+briefcase.list_chunks(path_or_file_id) -> [BlakeHash]
+briefcase.has_chunk(BlakeHash)         -> bool
+briefcase.get_chunk(BlakeHash)         -> bytes        (realm-scoped, signed)
+briefcase.request_chunk(BlakeHash)     -> stream
+briefcase.seed_chunk(BlakeHash, bytes) -> ok           (backup-only peers)
+```
+
+Small, stable surface. This is the client contract across web / CLI /
+editor-plugins / MCP.
+
+---
+
+## Phased Roadmap
+
+| Phase | Weeks | Output | Status |
+|---|---|---|---|
+| 0. Discovery + decisions | 1 | Archive `hecate-app-briefcase`; decide Option A/B/C; draft event vocabulary | ✅ Done |
+| 1. Skeleton trinity | 2–4 | `guide_briefcase_lifecycle` + `project_briefcase_files` + `query_briefcase_files` scaffolded; `upload_file` works end-to-end; whole-file storage; no mesh yet | ⏳ Scaffold in this PR |
+| 2. Mesh distribution | 5–7 | PubSub for events; RPC `briefcase.get_chunk`; full-file replication across realm peers | 📋 |
+| 3. Chunking + dedup | 8–10 | BLAKE3 1-MiB chunks; content-addressed store; parallel multi-peer fetch; resume | 📋 |
+| 4. E2E encryption | 11–13 | Per-realm key; per-file HKDF-derived keys; XChaCha20-Poly1305 | 📋 |
+| 5. UCAN sharing | 14–16 | External share links; time-bounded capability grants; revocation | 📋 |
+| 6. Native sync folder | 17–21 | Reconciler between events and `$HECATE_HOME/briefcase/realm/{r}/`; FS watcher | 📋 |
+| 7. Replication policy | 22–26 | Tunable per-folder replication; LAN peer affinity; quotas; backup-only peers | 📋 |
+
+---
+
+## Files to Create / Modify (Phase 1 Scaffold)
+
+| File | Purpose | Status |
+|---|---|---|
+| `apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src` | App manifest | ✅ |
+| `apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle_app.erl` | App entry | ✅ |
+| `apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle_sup.erl` | Top supervisor | ✅ |
+| `apps/guide_briefcase_lifecycle/include/briefcase_state.hrl` | State record | ✅ |
+| `apps/guide_briefcase_lifecycle/include/briefcase_status.hrl` | Status bit flags | ✅ |
+| `apps/guide_briefcase_lifecycle/src/briefcase_state.erl` | State module | ✅ |
+| `apps/guide_briefcase_lifecycle/src/briefcase_aggregate.erl` | Aggregate | ✅ |
+| `apps/guide_briefcase_lifecycle/src/upload_file/upload_file_v1.erl` | Command | ✅ |
+| `apps/guide_briefcase_lifecycle/src/upload_file/file_uploaded_v1.erl` | Event | ✅ |
+| `apps/guide_briefcase_lifecycle/src/upload_file/maybe_upload_file.erl` | Handler | ✅ |
+| `apps/project_briefcase_files/src/project_briefcase_files.app.src` | PRJ manifest | ✅ |
+| `apps/project_briefcase_files/src/project_briefcase_files_app.erl` | PRJ entry | ✅ |
+| `apps/project_briefcase_files/src/project_briefcase_files_sup.erl` | PRJ supervisor | ✅ |
+| `apps/project_briefcase_files/src/briefcase_lifecycle_to_files.erl` | Projection | ✅ |
+| `apps/query_briefcase_files/src/query_briefcase_files.app.src` | QRY manifest | ✅ |
+| `apps/query_briefcase_files/src/query_briefcase_files_app.erl` | QRY entry | ✅ |
+| `apps/query_briefcase_files/src/get_files_page/get_files_page_api.erl` | HTTP read endpoint | ✅ |
+
+Further verb slices (`revise_file`, `move_file`, `archive_file`,
+`purge_file`, `open_folder`, `collapse_folder`, `grant_access`,
+`revoke_access`, chunk-transfer verbs) follow in subsequent PRs per phase.
+
+---
+
+## Open Questions (Resolve Before Phase 2)
+
+1. **Realm master key storage** — passphrase-derived? TPM-backed?
+   Shamir secret sharing across trusted peers? Decide before Phase 4.
+2. **Aggregate boundary** — per-file aggregate or per-realm-filesystem
+   aggregate? Per-file = simpler; per-realm = stronger consistency.
+   Phase 1 scaffold uses **per-file aggregate** (file_id as stream).
+3. **Do existing `scribe` / `ledger` / `stage` apps already assume a
+   storage contract?** If yes, match it. If no, Briefcase defines it.
+4. **Metadata privacy** — encrypted chunks, but the event log exposes
+   paths / sizes / timestamps. Encrypt events themselves? Traffic-analysis
+   resistance is a Phase 6+ decision.
+5. **Quota enforcement** — per-user, per-realm, per-peer? Decentralized
+   enforcement is hard. Each peer enforcing its own quota is the simplest
+   v1 answer.
+
+---
+
+## Success Criteria (Phase 1)
+
+- [x] Three apps compile clean (`rebar3 compile --deps_only && rebar3 compile`)
+- [ ] `upload_file` command dispatches successfully through
+      `reckon_evoq_adapter` to `briefcase_store` (new ReckonDB store)
+- [ ] `file_uploaded_v1` event appears in the event log
+- [ ] `briefcase_lifecycle_to_files` projection updates the
+      `briefcase_files` ETS table
+- [ ] `GET /api/briefcase/files` returns the new file
+- [ ] No `services/` / `utils/` / `handlers/` horizontal layers created
+
+---
+
+## Non-Goals (v1)
+
+- Rich-text collaborative editing (Figma/Notion territory — out of scope)
+- Public internet-wide file sharing (realm-scoped; external = via UCAN)
+- Mobile clients (desktop + web first)
+- POSIX FUSE mount
+- Real-time video (that's the future Calls app, separate)
+
+---
+
+## Integration with `hecate-web`
+
+Current state: `hecate-web`'s Briefcase tab reads `$HECATE_HOME/briefcase/`
+directly via Tauri's FS plugin — **local-only, no event sourcing, no sync**.
+
+**Migration path**:
+
+- **Phase 1**: add a toggle in the Briefcase store: "Local scratch" (existing
+  Tauri FS code, unchanged) vs. "Realm synced" (new, calls
+  `query_briefcase_files` via `hecate-api`)
+- **Phase 6**: `guide_briefcase_lifecycle` grows a reconciler that
+  materializes `$HECATE_HOME/briefcase/realm/{r}/` from events. Existing
+  Tauri code keeps working; files appear in the folder automatically.
+
+No breaking changes to `hecate-web` at any phase.
+
+---
+
+## Marketing Surface
+
+Demo script (<2 minutes):
+
+1. Install Hecate on 3 laptops via `hecate-install`
+2. Drop `report.pdf` onto Briefcase tab on Laptop 1
+3. Watch it appear in Laptop 2's and Laptop 3's Briefcase within seconds
+4. Unplug Laptop 2 from Wi-Fi; file still opens locally
+5. Connect Laptop 3 to a hotel Wi-Fi behind NAT; still syncs
+6. Inspect disk on any peer: `grep` the file contents — find nothing
+
+Tagline candidate: *"Dropbox, but no one drops anything on anyone's server."*


### PR DESCRIPTION
## Summary

- Deletes empty `hecate-apps/hecate-app-briefcase` placeholder; Briefcase belongs inside the daemon as a capability, not as a plugin.
- Adds `plans/PLAN_BRIEFCASE.md` — full roadmap, architecture, event vocabulary, phased milestones.
- Scaffolds three new apps following the existing CMD/PRJ/QRY pattern:
  - `guide_briefcase_lifecycle` — CMD with aggregate + `upload_file` slice
  - `project_briefcase_files` — PRJ with `briefcase_lifecycle_to_files` projection
  - `query_briefcase_files` — QRY with `GET /api/briefcase/files` endpoint

## Rationale

Briefcase is the first-party **killer app** for the Macula mesh — a decentralized, E2E-encrypted, realm-scoped file store. It will be consumed as a storage capability by `scribe`, `ledger`, `stage`, and other Hecate apps. Positioned as the Dropbox/Nextcloud replacement that crosses the rebel → SMB audience chasm.

This PR is **Phase 1 only**: compile-clean scaffold, single verb slice (`upload_file`), whole-file storage, no mesh / chunking / encryption yet. Those phases land in follow-up PRs per the plan doc.

## Verified

- [x] `rebar3 compile` passes clean (all 3 new apps + existing apps unchanged)
- [x] Structure mirrors existing `guide_settings_lifecycle` / `project_settings` / `query_settings` pattern
- [x] No horizontal layers (`services/`, `utils/`, etc.) per hecate-daemon/CLAUDE.md
- [x] Event naming follows business-verb past-tense convention (`file_uploaded_v1`, not CRUD)
- [x] Status as bit-flag integer per project conventions

## What's NOT in this PR

- Chunk store (`briefcase_chunk_store`) — Phase 3
- Mesh emitter for PubSub broadcast — Phase 2
- Crypto (XChaCha20-Poly1305 + HKDF) — Phase 4
- UCAN-based sharing — Phase 5
- Further verb slices: `revise_file`, `move_file`, `archive_file`, `purge_file`, `open_folder`, `collapse_folder`, `grant_access`, `revoke_access`, chunk-transfer verbs
- `briefcase_store` ReckonDB instance registration in `hecate_app` boot — needs a follow-up touch
- `hecate-web` integration (Briefcase tab switches from Tauri-FS to API-backed)

## Test plan

- [ ] Review `plans/PLAN_BRIEFCASE.md` for architectural soundness
- [ ] Confirm event vocabulary matches naming conventions
- [ ] Sanity-check aggregate stream-id model (per-file aggregate) vs alternative (per-realm-filesystem aggregate)
- [ ] Decide local-truth model for v1 (Option C: API-only — currently assumed)

## Related

- Closes the discussion of plugin vs built-in for Briefcase.
- Deprecates and deletes `hecate-apps/hecate-app-briefcase` (was scaffold only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)