### PR TITLE
feat(briefcase): wire store + projection + route discovery (Phase 1.2)

### DIFF
--- a/apps/hecate_api/src/hecate_api_routes.erl
+++ b/apps/hecate_api/src/hecate_api_routes.erl
@@ -27,6 +27,7 @@
     guide_plugin_lifecycle, project_plugins, query_plugins,
     guide_launcher_lifecycle, project_launcher, query_launcher,
     guide_mpong_game_lifecycle, project_mpong_games, query_mpong_games,
+    guide_briefcase_lifecycle, project_briefcase_files, query_briefcase_files,
     query_observer
 ]).
 

--- a/apps/project_briefcase_files/src/project_briefcase_files_store.erl
+++ b/apps/project_briefcase_files/src/project_briefcase_files_store.erl
@@ -1,0 +1,69 @@
+%%% @doc Query facade for the briefcase_files ETS read model.
+%%%
+%%% Owns the public ETS table `briefcase_files`. Shared with
+%%% `briefcase_lifecycle_to_files` projection via `evoq_read_model_ets`
+%%% named-table support.
+%%%
+%%% Keys: file_id (binary). Values: map with
+%%% realm/path/mime_type/size/content_hash/author_did/uploaded_at/status.
+%%% @end
+-module(project_briefcase_files_store).
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([list/0, get/1, list_by_realm/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-define(TABLE, briefcase_files).
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%%====================================================================
+%% Query API (reads directly from public ETS)
+%%====================================================================
+
+-spec list() -> {ok, [map()]}.
+list() ->
+    try
+        {ok, [V || {_K, V} <- ets:tab2list(?TABLE)]}
+    catch
+        error:badarg -> {ok, []}
+    end.
+
+-spec get(binary()) -> {ok, map()} | {error, not_found}.
+get(FileId) when is_binary(FileId) ->
+    try
+        case ets:lookup(?TABLE, FileId) of
+            [{_, Entry}] -> {ok, Entry};
+            []           -> {error, not_found}
+        end
+    catch
+        error:badarg -> {error, not_found}
+    end.
+
+-spec list_by_realm(binary()) -> {ok, [map()]}.
+list_by_realm(Realm) when is_binary(Realm) ->
+    {ok, All} = ?MODULE:list(),
+    {ok, [E || #{realm := R} = E <- All, R =:= Realm]}.
+
+%%====================================================================
+%% gen_server callbacks — table lifecycle
+%%====================================================================
+
+init([]) ->
+    %% Create the public named table; projection writes via
+    %% evoq_read_model_ets with matching name.
+    case ets:info(?TABLE) of
+        undefined ->
+            ets:new(?TABLE, [named_table, public, set, {read_concurrency, true}]);
+        _ ->
+            ok
+    end,
+    {ok, #{}}.
+
+handle_call(_Req, _From, State) -> {reply, ok, State}.
+handle_cast(_Msg, State)        -> {noreply, State}.
+handle_info(_Info, State)       -> {noreply, State}.
+terminate(_Reason, _State)      -> ok.

--- a/apps/project_briefcase_files/src/project_briefcase_files_sup.erl
+++ b/apps/project_briefcase_files/src/project_briefcase_files_sup.erl
@@ -1,8 +1,8 @@
-%%% @doc Supervisor for project_briefcase_files.
+%%% @doc Top-level supervisor for project_briefcase_files (PRJ).
 %%%
-%%% Phase 1: no children yet — the projection is registered with evoq
-%%% at boot by `hecate_app`. Later phases may add a dedicated store
-%%% worker or read-model cache.
+%%% Starts the ETS store first (creates `briefcase_files` table), then
+%%% the merged projection that consumes briefcase lifecycle events from
+%%% the `briefcase_store` event log.
 %%% @end
 -module(project_briefcase_files_sup).
 -behaviour(supervisor).
@@ -13,10 +13,18 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    SupFlags = #{
-        strategy  => one_for_one,
-        intensity => 10,
-        period    => 10
-    },
-    Children = [],
-    {ok, {SupFlags, Children}}.
+    Children = [
+        %% ETS store (must start first — creates table)
+        #{id      => project_briefcase_files_store,
+          start   => {project_briefcase_files_store, start_link, []},
+          restart => permanent,
+          type    => worker},
+        %% Merged projection: briefcase lifecycle events -> files ETS
+        #{id      => briefcase_lifecycle_to_files,
+          start   => {evoq_projection, start_link,
+                      [briefcase_lifecycle_to_files, #{},
+                       #{store_id => briefcase_store}]},
+          restart => permanent,
+          type    => worker}
+    ],
+    {ok, {#{strategy => one_for_one, intensity => 10, period => 10}, Children}}.

--- a/apps/query_briefcase_files/src/get_files_page/get_files_page_api.erl
+++ b/apps/query_briefcase_files/src/get_files_page/get_files_page_api.erl
@@ -21,19 +21,9 @@ init(Req0, State) ->
     end.
 
 handle_get(Req0, _State) ->
-    case list_active() of
+    case project_briefcase_files_store:list() of
         {ok, Files} ->
             hecate_api_utils:json_ok(#{items => Files}, Req0);
         {error, Reason} ->
             hecate_api_utils:json_error(500, Reason, Req0)
-    end.
-
-%% Phase 1: read directly from the briefcase_files ETS table.
-%% Phase 2+: add a dedicated store module (project_briefcase_files_store).
-list_active() ->
-    try
-        Entries = [V || {_K, V} <- ets:tab2list(briefcase_files)],
-        {ok, Entries}
-    catch
-        error:badarg -> {ok, []}
     end.

--- a/rebar.config
+++ b/rebar.config
@@ -126,6 +126,11 @@
         project_mpong_games,        %% PRJ: game state ETS projection
         query_mpong_games,          %% QRY: game API endpoints
 
+        %% Briefcase (mesh-backed file sharing — killer app)
+        guide_briefcase_lifecycle,  %% CMD: upload/revise/move/archive/purge/grant/revoke
+        project_briefcase_files,    %% PRJ: files ETS projection
+        query_briefcase_files,      %% QRY: file API endpoints
+
         %% Observer (BEAM diagnostics, read-only introspection)
         query_observer,
 

--- a/src/hecate_app.erl
+++ b/src/hecate_app.erl
@@ -41,7 +41,8 @@
     {payments_store,            "payments",            "Payments (payment process)"},
     {plugins_store,             "plugins",             "Plugins (install/upgrade/remove)"},
     {launcher_store,            "launcher",            "Launcher (sidebar layout lifecycle)"},
-    {mpong_store,               "mpong",               "MPong (mesh pong game lifecycle)"}
+    {mpong_store,               "mpong",               "MPong (mesh pong game lifecycle)"},
+    {briefcase_store,           "briefcase",           "Briefcase (file upload, revise, move, archive, grant)"}
 ]).
 
 %% Site store (cluster nodes, site-level state).


### PR DESCRIPTION
## Stacked on #5

Depends on PR #5 (scaffold). Merge base is `feat/briefcase-scaffold` to keep the review units tight.

## Summary

Wires the Briefcase capability into the daemon's boot + routing infrastructure. With this PR merged (and #5), the daemon:

1. Creates `briefcase_store` (ReckonDB) at boot in `hecate_app:start/2`
2. Starts `project_briefcase_files_store` (ETS owner, mirrors `project_settings_store`)
3. Starts `evoq_projection` for `briefcase_lifecycle_to_files` consuming the `briefcase_store` event log
4. Exposes `GET /api/briefcase/files` via `hecate_api_routes` auto-discovery
5. Includes the three briefcase apps in the `relx` release

Event → Projection → Query path is now live end-to-end — *upload endpoint in next PR lights it up*.

## Files

| File | Change |
|---|---|
| `src/hecate_app.erl` | add `briefcase_store` to `?STORES` |
| `rebar.config` | add 3 apps to relx release |
| `apps/hecate_api/src/hecate_api_routes.erl` | add 3 apps to `?HECATE_APPS` |
| `apps/project_briefcase_files/src/project_briefcase_files_store.erl` | new — ETS owner + query API |
| `apps/project_briefcase_files/src/project_briefcase_files_sup.erl` | start store + projection children |
| `apps/query_briefcase_files/src/get_files_page/get_files_page_api.erl` | use new store module instead of direct ETS |

## Verified

- [x] `rebar3 compile` passes clean
- [x] Pattern matches `project_settings_sup` / `project_settings_store` exactly
- [x] Event store registered where all others live (`?STORES` in `hecate_app`)
- [x] Route discovery happens via the standard `?HECATE_APPS` list — no special casing

## What's next

- **PR #3**: `upload_file_api` (POST multipart) + `briefcase_content_store` (on-disk bytes) — uploads become functional
- **PR #4**: `get_file_by_id_api` + `get_file_content_api` — downloads functional; round-trip complete
- **PR #5**: hecate-web drag-and-drop UI (in the hecate-web repo)
- **PR #6**: Mesh emitter + subscriber — the "appears on every peer" moment

🤖 Generated with [Claude Code](https://claude.com/claude-code)