### PR TITLE
feat(briefcase): upload_file_api + on-disk content store (Phase 1.3)

### DIFF
--- a/apps/guide_briefcase_lifecycle/src/briefcase_content_store.erl
+++ b/apps/guide_briefcase_lifecycle/src/briefcase_content_store.erl
@@ -1,0 +1,58 @@
+%%% @doc On-disk content store for Briefcase files.
+%%%
+%%% Phase 1: whole-file storage, content-addressed. Each file lives at:
+%%%     $HECATE_HOME/hecate-daemon/briefcase/content/{XX}/{FileId}.bin
+%%% where `XX` is the first 2 hex chars of the file_id (BLAKE3 hash) —
+%%% load-spreading over 256 sub-directories.
+%%%
+%%% Phase 3 replaces this with chunked storage:
+%%%     .../chunks/{XX}/{ChunkHash}.enc
+%%% and files become ordered sequences of chunk hashes.
+%%% @end
+-module(briefcase_content_store).
+
+-export([put/2, get/1, delete/1, exists/1]).
+-export([content_dir/0, content_path/1]).
+
+%% @doc Root directory for content storage.
+-spec content_dir() -> file:filename().
+content_dir() ->
+    Dir = filename:join(shared_paths:base_dir(), "briefcase/content"),
+    ok = filelib:ensure_path(Dir),
+    Dir.
+
+%% @doc Absolute on-disk path for a given file_id.
+-spec content_path(binary()) -> file:filename().
+content_path(FileId) when is_binary(FileId), byte_size(FileId) >= 2 ->
+    Prefix = binary:part(FileId, 0, 2),
+    SubDir = filename:join(content_dir(), binary_to_list(Prefix)),
+    ok = filelib:ensure_path(SubDir),
+    Name = <<FileId/binary, ".bin">>,
+    filename:join(SubDir, binary_to_list(Name)).
+
+%% @doc Write content bytes. Idempotent — same FileId overwrites.
+-spec put(binary(), binary()) -> ok | {error, term()}.
+put(FileId, Content) when is_binary(FileId), is_binary(Content) ->
+    Path = content_path(FileId),
+    file:write_file(Path, Content).
+
+%% @doc Read content bytes.
+-spec get(binary()) -> {ok, binary()} | {error, term()}.
+get(FileId) when is_binary(FileId) ->
+    Path = content_path(FileId),
+    file:read_file(Path).
+
+%% @doc Remove a file's content.
+-spec delete(binary()) -> ok | {error, term()}.
+delete(FileId) when is_binary(FileId) ->
+    Path = content_path(FileId),
+    case file:delete(Path) of
+        ok -> ok;
+        {error, enoent} -> ok;
+        {error, _} = E -> E
+    end.
+
+%% @doc Check if content is present locally.
+-spec exists(binary()) -> boolean().
+exists(FileId) when is_binary(FileId) ->
+    filelib:is_regular(content_path(FileId)).

--- a/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src
+++ b/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src
@@ -8,7 +8,11 @@
         stdlib,
         reckon_db,
         evoq,
-        reckon_evoq
+        reckon_evoq,
+        macula,
+        cowboy,
+        shared,
+        hecate_api
     ]},
     {env, []},
     {modules, []},

--- a/apps/guide_briefcase_lifecycle/src/upload_file/upload_file_api.erl
+++ b/apps/guide_briefcase_lifecycle/src/upload_file/upload_file_api.erl
@@ -1,0 +1,101 @@
+%%% @doc Upload file API handler: POST /api/briefcase/files
+%%%
+%%% Accepts multipart/form-data with one `file` part (the binary content)
+%%% and optional form fields:
+%%%   - path:      logical path for the file (defaults to the upload filename)
+%%%   - mime_type: MIME override (defaults to the browser-supplied Content-Type)
+%%%
+%%% On success:
+%%%   - computes BLAKE3 of content → file_id + content_hash
+%%%   - writes content to briefcase_content_store
+%%%   - dispatches `upload_file_v1` command → emits `file_uploaded_v1`
+%%%
+%%% Response: 201 JSON `{ok: true, file_id, path, size}`.
+%%% @end
+-module(upload_file_api).
+
+-export([init/2, routes/0]).
+
+routes() -> [{"/api/briefcase/files/upload", ?MODULE, []}].
+
+init(Req0, State) ->
+    case cowboy_req:method(Req0) of
+        <<"POST">> -> handle_post(Req0, State);
+        _          -> hecate_api_utils:method_not_allowed(Req0)
+    end.
+
+handle_post(Req0, _State) ->
+    case read_multipart(Req0, #{}) of
+        {ok, #{file := Content} = Fields, Req1} ->
+            Filename  = maps:get(filename,  Fields, <<"untitled">>),
+            DefMime   = maps:get(mime_hint, Fields, <<"application/octet-stream">>),
+            Path      = maps:get(path,      Fields, Filename),
+            MimeType  = maps:get(mime_type, Fields, DefMime),
+            process_upload(Content, Path, MimeType, Req1);
+        {ok, _Fields, Req1} ->
+            hecate_api_utils:json_error(400, <<"Missing file part">>, Req1);
+        {error, Reason, Req1} ->
+            hecate_api_utils:json_error(400, Reason, Req1)
+    end.
+
+%%% ===================================================================
+%%% Internal
+%%% ===================================================================
+
+process_upload(Content, Path, MimeType, Req) ->
+    FileId = macula_blake3_nif:hash_hex(Content),
+    Size   = byte_size(Content),
+    case briefcase_content_store:put(FileId, Content) of
+        ok ->
+            dispatch_upload(FileId, Path, MimeType, Size, Req);
+        {error, Reason} ->
+            hecate_api_utils:json_error(500, {storage_error, Reason}, Req)
+    end.
+
+dispatch_upload(FileId, Path, MimeType, Size, Req) ->
+    Realm      = application:get_env(hecate, realm, <<"io.macula">>),
+    AuthorDid  = application:get_env(hecate, gateway_identity,
+                                     <<"mri:agent:io.macula/hecate">>),
+    UploadedAt = erlang:system_time(millisecond),
+    Cmd = upload_file_v1:new(FileId, Realm, to_bin(Path), to_bin(MimeType),
+                             Size, FileId, AuthorDid, UploadedAt),
+    case maybe_upload_file:dispatch(Cmd) of
+        {ok, _Version, _Events} ->
+            hecate_api_utils:json_ok(
+                #{file_id => FileId, path => to_bin(Path), size => Size},
+                Req);
+        {error, Reason} ->
+            %% Content was already written; remove it to keep disk clean.
+            _ = briefcase_content_store:delete(FileId),
+            hecate_api_utils:json_error(400, Reason, Req)
+    end.
+
+read_multipart(Req0, Acc) ->
+    case cowboy_req:read_part(Req0) of
+        {ok, Headers, Req1} ->
+            case cow_multipart:form_data(Headers) of
+                {data, FieldName} ->
+                    {ok, Body, Req2} = cowboy_req:read_part_body(Req1),
+                    read_multipart(Req2,
+                        Acc#{binary_to_atom(FieldName, utf8) => Body});
+                {file, _FieldName, Filename, ContentType} ->
+                    {ok, Body, Req2} = read_full_part_body(Req1, <<>>),
+                    read_multipart(Req2,
+                        Acc#{file      => Body,
+                             filename  => Filename,
+                             mime_hint => ContentType})
+            end;
+        {done, Req1} ->
+            {ok, Acc, Req1}
+    end.
+
+read_full_part_body(Req0, Acc) ->
+    case cowboy_req:read_part_body(Req0) of
+        {ok, Body, Req1} ->
+            {ok, <<Acc/binary, Body/binary>>, Req1};
+        {more, Body, Req1} ->
+            read_full_part_body(Req1, <<Acc/binary, Body/binary>>)
+    end.
+
+to_bin(B) when is_binary(B) -> B;
+to_bin(L) when is_list(L)   -> list_to_binary(L).


### PR DESCRIPTION
## Stacked on #6 which is stacked on #5

Merge base: `feat/briefcase-wiring`. Reviewable as a tight unit.

## Summary

Lights up the **upload** half of the round-trip:

```
POST /api/briefcase/files/upload (multipart/form-data)
  → parse file part + metadata
  → BLAKE3 of content → file_id
  → briefcase_content_store:put(file_id, bytes) writes to disk
  → maybe_upload_file:dispatch(cmd) → file_uploaded_v1 event
  → briefcase_lifecycle_to_files projection → briefcase_files ETS
  → visible via GET /api/briefcase/files (from PR #6)
```

## Files

| File | Change |
|---|---|
| `apps/guide_briefcase_lifecycle/src/briefcase_content_store.erl` | new — content-addressed disk store, 256-bucket spread |
| `apps/guide_briefcase_lifecycle/src/upload_file/upload_file_api.erl` | new — multipart POST handler |
| `apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src` | +macula/cowboy/shared/hecate_api deps |

## URL convention

Following the existing project pattern (each verb = own URL, not REST-by-method):

- `POST /api/briefcase/files/upload` → CMD slice
- `GET /api/briefcase/files` → QRY slice (from PR #6)

Future: `POST /api/briefcase/files/:id/revise`, `POST /api/briefcase/files/:id/archive`, etc.

## Multipart form

- `file` (required) — the bytes
- `path` (optional) — logical path; defaults to upload filename
- `mime_type` (optional) — override; defaults to browser-supplied Content-Type

## Test (after merge)

```bash
# Upload
curl --unix-socket ~/.hecate/hecate-daemon/sockets/api.sock \
     -X POST http://localhost/api/briefcase/files/upload \
     -F "file=@report.pdf" -F "path=reports/q1.pdf"

# Verify
curl --unix-socket ~/.hecate/hecate-daemon/sockets/api.sock \
     http://localhost/api/briefcase/files
```

## Roll-back safety

If `dispatch` fails after content is written, the file is deleted from disk before returning the error. Keeps disk aligned with the event log — no orphaned chunks.

## Verified

- [x] `rebar3 compile` passes clean
- [x] Multipart pattern matches `serve_llm/transcribe_audio_api` (copy-then-adapt)
- [x] Identity/realm pulled from standard hecate app env (same as `announce_mesh_presence`)

## Next PR

**#8: download half** — `GET /api/briefcase/files/:id` (metadata) + `GET /api/briefcase/files/:id/content` (bytes). Closes the single-peer round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)