### PR TITLE
feat(briefcase): download endpoints — metadata + content (Phase 1.4)

### DIFF
--- a/apps/query_briefcase_files/src/get_file_by_id/get_file_by_id_api.erl
+++ b/apps/query_briefcase_files/src/get_file_by_id/get_file_by_id_api.erl
@@ -1,0 +1,24 @@
+%%% @doc API handler: GET /api/briefcase/files/:id
+%%%
+%%% Returns metadata for a single briefcase file.
+%%% @end
+-module(get_file_by_id_api).
+
+-export([init/2, routes/0]).
+
+routes() -> [{"/api/briefcase/files/:id", ?MODULE, []}].
+
+init(Req0, State) ->
+    case cowboy_req:method(Req0) of
+        <<"GET">> -> handle_get(Req0, State);
+        _         -> hecate_api_utils:method_not_allowed(Req0)
+    end.
+
+handle_get(Req0, _State) ->
+    FileId = cowboy_req:binding(id, Req0),
+    case project_briefcase_files_store:get(FileId) of
+        {ok, Entry} ->
+            hecate_api_utils:json_ok(Entry, Req0);
+        {error, not_found} ->
+            hecate_api_utils:json_error(404, <<"File not found">>, Req0)
+    end.

--- a/apps/query_briefcase_files/src/get_file_content/get_file_content_api.erl
+++ b/apps/query_briefcase_files/src/get_file_content/get_file_content_api.erl
@@ -1,0 +1,61 @@
+%%% @doc API handler: GET /api/briefcase/files/:id/content
+%%%
+%%% Streams raw bytes for a briefcase file. Content is served with
+%%% the Content-Type from the stored metadata, defaulting to
+%%% `application/octet-stream` when absent.
+%%%
+%%% NOTE: content_path duplicated from briefcase_content_store to keep
+%%% query_briefcase_files free of a cross-layer dep on
+%%% guide_briefcase_lifecycle. A follow-up PR may unify both into a
+%%% shared storage module once a second reader emerges (e.g. mesh
+%%% RPC handler `briefcase.get_chunk`).
+%%% @end
+-module(get_file_content_api).
+
+-export([init/2, routes/0]).
+
+routes() -> [{"/api/briefcase/files/:id/content", ?MODULE, []}].
+
+init(Req0, State) ->
+    case cowboy_req:method(Req0) of
+        <<"GET">> -> handle_get(Req0, State);
+        _         -> hecate_api_utils:method_not_allowed(Req0)
+    end.
+
+handle_get(Req0, _State) ->
+    FileId = cowboy_req:binding(id, Req0),
+    case project_briefcase_files_store:get(FileId) of
+        {ok, #{mime_type := MimeType}} ->
+            serve_content(FileId, MimeType, Req0);
+        {ok, _EntryWithoutMime} ->
+            serve_content(FileId, undefined, Req0);
+        {error, not_found} ->
+            hecate_api_utils:json_error(404, <<"File not found">>, Req0)
+    end.
+
+serve_content(FileId, MimeType, Req0) ->
+    case file:read_file(content_path(FileId)) of
+        {ok, Body} ->
+            Headers = #{
+                <<"content-type">>   => mime_or_default(MimeType),
+                <<"content-length">> => integer_to_binary(byte_size(Body))
+            },
+            cowboy_req:reply(200, Headers, Body, Req0);
+        {error, enoent} ->
+            hecate_api_utils:json_error(404,
+                <<"Content not locally available on this peer">>, Req0);
+        {error, Reason} ->
+            hecate_api_utils:json_error(500, Reason, Req0)
+    end.
+
+content_path(FileId) when is_binary(FileId), byte_size(FileId) >= 2 ->
+    Prefix = binary:part(FileId, 0, 2),
+    SubDir = filename:join(
+        [shared_paths:base_dir(), "briefcase/content",
+         binary_to_list(Prefix)]),
+    Name = <<FileId/binary, ".bin">>,
+    filename:join(SubDir, binary_to_list(Name)).
+
+mime_or_default(undefined) -> <<"application/octet-stream">>;
+mime_or_default(Mime) when is_binary(Mime) -> Mime;
+mime_or_default(Mime) when is_list(Mime) -> list_to_binary(Mime).

--- a/apps/query_briefcase_files/src/query_briefcase_files.app.src
+++ b/apps/query_briefcase_files/src/query_briefcase_files.app.src
@@ -6,6 +6,9 @@
     {applications, [
         kernel,
         stdlib,
+        cowboy,
+        shared,
+        hecate_api,
         project_briefcase_files
     ]},
     {env, []},


### PR DESCRIPTION
## Stacked on #7 → #6 → #5

Merge base: `feat/briefcase-upload`.

## Summary

Closes the single-peer round-trip. Two new QRY slices:

| Endpoint | Returns |
|---|---|
| `GET /api/briefcase/files/:id` | metadata JSON (from `briefcase_files` ETS) |
| `GET /api/briefcase/files/:id/content` | raw bytes with correct Content-Type |

After this + #5/#6/#7 merge, the full upload→list→download pipeline works on a single peer.

## Test (after merge)

```bash
SOCK=$HOME/.hecate/hecate-daemon/sockets/api.sock

# 1. Upload
curl --unix-socket $SOCK -X POST \
     http://localhost/api/briefcase/files/upload \
     -F "file=@/etc/hostname" -F "path=hello.txt"
# → {"ok":true,"file_id":"ab12…","path":"hello.txt","size":42}

# 2. List
curl --unix-socket $SOCK http://localhost/api/briefcase/files

# 3. Get metadata
curl --unix-socket $SOCK http://localhost/api/briefcase/files/ab12…

# 4. Get content
curl --unix-socket $SOCK http://localhost/api/briefcase/files/ab12…/content
```

## Route collision note

`/api/briefcase/files/upload` (literal) and `/api/briefcase/files/:id` (binding) share a prefix. Cowboy resolves literal segments before bindings during tree compilation, so no collision.

## Content-path duplication

Intentional. `get_file_content_api` re-derives the on-disk path rather than calling `briefcase_content_store` in `guide_briefcase_lifecycle` (QRY shouldn't depend on CMD). 10 lines duplicated. Unified in a follow-up once a third reader arrives (mesh RPC handler).

## Verified

- [x] `rebar3 compile` passes clean
- [x] Cowboy handles the `/upload` vs `/:id` disambiguation automatically

## Next PR

**#10: mesh emitter + subscriber** — when file_uploaded event fires, pubsub broadcast to realm; other peers subscribe, fetch content via RPC, project locally. **This is the drop-file-appears-on-all-peers moment.**

Between: **PR #9 (hecate-web drag-and-drop UI)** lands in the hecate-web repo — lets us actually click-and-drag instead of curling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)