### PR TITLE
feat(briefcase): mesh distribution — publish, subscribe, fetch (Phase 2)

### DIFF
--- a/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src
+++ b/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src
@@ -12,7 +12,8 @@
         macula,
         cowboy,
         shared,
-        hecate_api
+        hecate_api,
+        hecate_mesh
     ]},
     {env, []},
     {modules, []},

--- a/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle_app.erl
+++ b/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle_app.erl
@@ -5,6 +5,10 @@
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
+    %% Register the mesh RPC advertisement for briefcase.get_chunk.
+    %% hecate_mesh_client queues it and applies when the mesh activates —
+    %% safe to call even before mesh is up.
+    ok = serve_file_content_rpc:register(),
     guide_briefcase_lifecycle_sup:start_link().
 
 stop(_State) ->

--- a/apps/guide_briefcase_lifecycle/src/serve_file_content_rpc/serve_file_content_rpc.erl
+++ b/apps/guide_briefcase_lifecycle/src/serve_file_content_rpc/serve_file_content_rpc.erl
@@ -1,0 +1,60 @@
+%%% @doc RPC handler: `<realm>.briefcase.get_chunk`.
+%%%
+%%% Serves content bytes from the local briefcase_content_store when
+%%% another peer in the realm requests them. Called from the mesh
+%%% subscriber flow on peers that do not yet have the content locally.
+%%%
+%%% Args (incoming call payload):
+%%%     #{ file_id => binary() }
+%%%
+%%% Reply:
+%%%     {ok, #{ file_id => binary(),
+%%%             size    => non_neg_integer(),
+%%%             bytes   => binary() }}
+%%%   | {error, not_available}
+%%%
+%%% Phase 2 serves whole files. Phase 3 replaces this with true chunk
+%%% fetches (keyed by content-addressed chunk hash).
+%%% @end
+-module(serve_file_content_rpc).
+
+-export([procedure/1, handle/1, register/0]).
+
+-spec procedure(binary()) -> binary().
+procedure(Realm) when is_binary(Realm) ->
+    <<Realm/binary, ".briefcase.get_chunk">>.
+
+%% @doc RPC handler. Signature matches macula:advertise expectations.
+-spec handle(map()) -> {ok, map()} | {error, term()}.
+handle(#{<<"file_id">> := FileId}) ->
+    handle_file_id(FileId);
+handle(#{file_id := FileId}) ->
+    handle_file_id(FileId);
+handle(_) ->
+    {error, missing_file_id}.
+
+handle_file_id(FileId) when is_binary(FileId) ->
+    case briefcase_content_store:get(FileId) of
+        {ok, Bytes} ->
+            {ok, #{
+                file_id => FileId,
+                size    => byte_size(Bytes),
+                bytes   => Bytes
+            }};
+        {error, enoent} ->
+            {error, not_available};
+        {error, Reason} ->
+            {error, Reason}
+    end;
+handle_file_id(_) ->
+    {error, invalid_file_id}.
+
+%% @doc Register the advertisement with the mesh client. Safe to call
+%% at boot — the subscription is queued until the mesh activates.
+-spec register() -> ok.
+register() ->
+    Realm = application:get_env(hecate, realm, <<"io.macula">>),
+    hecate_mesh_client:register_advertisement(
+        procedure(Realm),
+        fun ?MODULE:handle/1
+    ).

--- a/apps/guide_briefcase_lifecycle/src/share_file_in_mesh/share_file_in_mesh.erl
+++ b/apps/guide_briefcase_lifecycle/src/share_file_in_mesh/share_file_in_mesh.erl
@@ -1,0 +1,65 @@
+%%% @doc Publish a briefcase file as a mesh integration fact.
+%%%
+%%% Called after a successful local `upload_file_v1` dispatch. Publishes
+%%% `file_shared_v1` to the realm-scoped topic:
+%%%     `<realm>.briefcase.file_shared`
+%%%
+%%% Subscribers on other peers in the realm receive this fact and may
+%%% fetch the content via the `<realm>.briefcase.get_chunk` RPC.
+%%%
+%%% Integration fact schema (stable contract; distinct from internal
+%%% `file_uploaded_v1` domain event):
+%%%
+%%%     #{ event_type    => <<"file_shared_v1">>,
+%%%        file_id       => binary(),     %% BLAKE3 hex of content
+%%%        realm         => binary(),
+%%%        path          => binary(),
+%%%        mime_type     => binary(),
+%%%        size          => non_neg_integer(),
+%%%        content_hash  => binary(),
+%%%        author_did    => binary(),
+%%%        shared_at     => integer() }   %% wallclock ms
+%%%
+%%% Fire-and-forget on the caller's behalf — never blocks the command
+%%% dispatch path on mesh availability.
+%%% @end
+-module(share_file_in_mesh).
+
+-export([share/1, topic/1]).
+
+-spec share(map()) -> ok | {error, term()}.
+share(#{file_id := FileId, realm := Realm, path := Path,
+        mime_type := MimeType, size := Size, content_hash := Hash,
+        author_did := AuthorDid}) ->
+    Fact = #{
+        event_type    => <<"file_shared_v1">>,
+        file_id       => FileId,
+        realm         => Realm,
+        path          => Path,
+        mime_type     => MimeType,
+        size          => Size,
+        content_hash  => Hash,
+        author_did    => AuthorDid,
+        shared_at     => erlang:system_time(millisecond)
+    },
+    Topic = topic(Realm),
+    try hecate_mesh_client:publish(Topic, Fact) of
+        ok -> ok;
+        {error, Reason} ->
+            logger:warning("[briefcase] mesh publish failed for ~s: ~p",
+                           [FileId, Reason]),
+            {error, Reason};
+        Other ->
+            logger:warning("[briefcase] mesh publish unexpected: ~p", [Other]),
+            {error, Other}
+    catch Class:Error ->
+        logger:warning("[briefcase] mesh publish crashed: ~p:~p",
+                       [Class, Error]),
+        {error, {Class, Error}}
+    end;
+share(_Incomplete) ->
+    {error, missing_fields}.
+
+-spec topic(binary()) -> binary().
+topic(Realm) when is_binary(Realm) ->
+    <<Realm/binary, ".briefcase.file_shared">>.

--- a/apps/guide_briefcase_lifecycle/src/upload_file/maybe_upload_file.erl
+++ b/apps/guide_briefcase_lifecycle/src/upload_file/maybe_upload_file.erl
@@ -53,11 +53,21 @@ dispatch(Cmd) ->
         payload        = CmdMap#{command_type => upload_file},
         metadata       = #{timestamp => erlang:system_time(millisecond)}
     },
-    evoq_dispatcher:dispatch(EvoqCmd, #{
+    Result = evoq_dispatcher:dispatch(EvoqCmd, #{
         store_id    => briefcase_store,
         adapter     => reckon_evoq_adapter,
         consistency => eventual
-    }).
+    }),
+    case Result of
+        {ok, _Version, _Events} ->
+            %% Fire-and-forget publication of the integration fact to the
+            %% realm-scoped mesh topic. Local state is always authoritative;
+            %% mesh failures do not roll back the local upload.
+            _ = share_file_in_mesh:share(CmdMap),
+            Result;
+        _ ->
+            Result
+    end.
 
 %% Internal
 

--- a/apps/project_briefcase_files/src/listen_for_shared_files/listen_for_shared_files.erl
+++ b/apps/project_briefcase_files/src/listen_for_shared_files/listen_for_shared_files.erl
@@ -1,0 +1,133 @@
+%%% @doc Mesh subscriber for `<realm>.briefcase.file_shared` facts.
+%%%
+%%% When another peer in the realm publishes a `file_shared_v1` fact,
+%%% this process:
+%%%   1. skips the fact if we already have the file locally
+%%%   2. fetches content via `<realm>.briefcase.get_chunk` RPC
+%%%   3. writes content to the local briefcase_content_store
+%%%   4. inserts the metadata into the briefcase_files ETS so the UI
+%%%      shows the new file immediately
+%%%
+%%% Phase 2 (this PR): whole-file fetch per fact, no retry queue.
+%%% Phase 3+: chunk-level parallel fetch, fallback to other peers,
+%%% signed-chunk verification, resume-on-reconnect.
+%%% @end
+-module(listen_for_shared_files).
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-define(RPC_TIMEOUT_MS, 30000).
+
+-record(state, {
+    realm   :: binary(),
+    topic   :: binary(),
+    rpc     :: binary()
+}).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    Realm = application:get_env(hecate, realm, <<"io.macula">>),
+    Topic = <<Realm/binary, ".briefcase.file_shared">>,
+    Rpc   = <<Realm/binary, ".briefcase.get_chunk">>,
+    Self  = self(),
+    Callback = fun(Fact) ->
+        Self ! {shared_fact, Fact},
+        ok
+    end,
+    hecate_mesh_client:register_subscription(Topic, Callback),
+    logger:info("[briefcase] subscribed to mesh topic ~s", [Topic]),
+    {ok, #state{realm = Realm, topic = Topic, rpc = Rpc}}.
+
+handle_call(_Req, _From, State) -> {reply, ok, State}.
+handle_cast(_Msg, State)        -> {noreply, State}.
+
+handle_info({shared_fact, Fact}, State) ->
+    _ = process_fact(Fact, State),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) -> ok.
+
+%%% ===================================================================
+%%% Internal
+%%% ===================================================================
+
+process_fact(Fact, State) ->
+    case extract_file_id(Fact) of
+        {ok, FileId} ->
+            case project_briefcase_files_store:get(FileId) of
+                {ok, _Entry} ->
+                    %% Already seen — idempotent re-delivery
+                    ok;
+                {error, not_found} ->
+                    fetch_and_store(FileId, Fact, State)
+            end;
+        {error, _} = E ->
+            logger:warning("[briefcase] malformed shared fact: ~p", [Fact]),
+            E
+    end.
+
+fetch_and_store(FileId, Fact, #state{rpc = Rpc}) ->
+    case hecate_mesh_client:get_client() of
+        {ok, Client} when is_pid(Client) ->
+            Args = #{file_id => FileId},
+            case macula:call(Client, Rpc, Args, ?RPC_TIMEOUT_MS) of
+                {ok, #{<<"bytes">> := Bytes} = _Reply} ->
+                    finalize(FileId, Bytes, Fact);
+                {ok, #{bytes := Bytes}} ->
+                    finalize(FileId, Bytes, Fact);
+                {ok, Other} ->
+                    logger:warning("[briefcase] unexpected RPC reply for ~s: ~p",
+                                   [FileId, Other]),
+                    {error, bad_reply};
+                {error, Reason} ->
+                    logger:warning("[briefcase] RPC ~s failed for ~s: ~p",
+                                   [Rpc, FileId, Reason]),
+                    {error, Reason}
+            end;
+        _ ->
+            logger:warning("[briefcase] mesh not activated; cannot fetch ~s",
+                           [FileId]),
+            {error, mesh_not_activated}
+    end.
+
+finalize(FileId, Bytes, Fact) ->
+    ok = briefcase_content_store:put(FileId, Bytes),
+    Entry = fact_to_entry(Fact),
+    ets:insert(briefcase_files, {FileId, Entry}),
+    logger:info("[briefcase] received shared file ~s (~b bytes)",
+                [FileId, byte_size(Bytes)]),
+    ok.
+
+%%% --- Helpers ------------------------------------------------------
+
+extract_file_id(#{<<"file_id">> := FileId}) when is_binary(FileId) -> {ok, FileId};
+extract_file_id(#{file_id     := FileId}) when is_binary(FileId) -> {ok, FileId};
+extract_file_id(_)                                               -> {error, no_file_id}.
+
+fact_to_entry(Fact) ->
+    #{
+        file_id      => gf(file_id, Fact),
+        realm        => gf(realm, Fact),
+        path         => gf(path, Fact),
+        mime_type    => gf(mime_type, Fact),
+        size         => gf(size, Fact),
+        content_hash => gf(content_hash, Fact),
+        author_did   => gf(author_did, Fact),
+        uploaded_at  => gf(shared_at, Fact),
+        status       => 1,
+        status_label => <<"Shared">>
+    }.
+
+gf(Key, Map) when is_atom(Key) ->
+    case maps:find(Key, Map) of
+        {ok, V} -> V;
+        error ->
+            BinKey = atom_to_binary(Key, utf8),
+            maps:get(BinKey, Map, undefined)
+    end.

--- a/apps/project_briefcase_files/src/project_briefcase_files.app.src
+++ b/apps/project_briefcase_files/src/project_briefcase_files.app.src
@@ -7,6 +7,8 @@
         kernel,
         stdlib,
         evoq,
+        macula,
+        hecate_mesh,
         guide_briefcase_lifecycle
     ]},
     {env, []},

--- a/apps/project_briefcase_files/src/project_briefcase_files_sup.erl
+++ b/apps/project_briefcase_files/src/project_briefcase_files_sup.erl
@@ -1,8 +1,9 @@
 %%% @doc Top-level supervisor for project_briefcase_files (PRJ).
 %%%
 %%% Starts the ETS store first (creates `briefcase_files` table), then
-%%% the merged projection that consumes briefcase lifecycle events from
-%%% the `briefcase_store` event log.
+%%% the merged projection consuming local briefcase lifecycle events,
+%%% then the mesh subscriber that catches `file_shared_v1` facts from
+%%% other peers in the realm.
 %%% @end
 -module(project_briefcase_files_sup).
 -behaviour(supervisor).
@@ -24,6 +25,12 @@ init([]) ->
           start   => {evoq_projection, start_link,
                       [briefcase_lifecycle_to_files, #{},
                        #{store_id => briefcase_store}]},
+          restart => permanent,
+          type    => worker},
+        %% Mesh subscriber: receives file_shared_v1 facts from peers and
+        %% fetches content via briefcase.get_chunk RPC.
+        #{id      => listen_for_shared_files,
+          start   => {listen_for_shared_files, start_link, []},
           restart => permanent,
           type    => worker}
     ],

--- a/plans/PLAN_BRIEFCASE.md
+++ b/plans/PLAN_BRIEFCASE.md
@@ -41,6 +41,31 @@ Reasons:
 The prior `hecate-apps/hecate-app-briefcase` placeholder repo has been
 deleted (was empty scaffold; capability belongs inside the daemon).
 
+## Transport Decision — No True P2P (2026-04-20)
+
+**All mesh traffic transits macula-relay. We do not pursue direct
+peer-to-peer QUIC between nodes.**
+
+Why:
+
+- NAT traversal (ICE/STUN/TURN-equivalent over QUIC) is complex, unreliable
+  across hostile NATs, and demands session signalling we don't want to own.
+- Relay-mediated flow is simpler to debug, monitor, rate-limit, and bill.
+- The relay mesh itself is already global (`relay-{country}-{city}.macula.io`
+  — hundreds of nodes) and is part of our moat, not an afterthought.
+- UCAN authorization enforcement sits cleanly at the relay.
+
+Consequences for Briefcase:
+
+- `file_shared` pubsub facts flow A → relay → B.
+- `briefcase.get_chunk` RPC flows B → relay → A → relay → B.
+- Content bytes traverse relays for their entire path. Bandwidth is
+  the relay operator's concern; optimise via (a) chunking so first-byte
+  latency is low, (b) realm-locality — peers and relays in the same
+  geographic region, (c) caching hints.
+- No fallback to direct P2P. If relays are unreachable, Briefcase is
+  unreachable — this is an explicit tradeoff.
+
 ---
 
 ## Architecture


### PR DESCRIPTION
## Stacked on #8 → #7 → #6 → #5

Merge base: `feat/briefcase-download`.

## The magic moment

With this PR merged, a file uploaded on peer A appears in the Briefcase of every other peer in the realm. Automatically. Via macula-relay.

```
Peer A: upload_file_api → dispatch → file_uploaded_v1 (local event)
     ↓ share_file_in_mesh publishes integration fact
macula-relay: fans out to all subscribers
     ↓
Peer B: listen_for_shared_files receives fact
     ↓ calls briefcase.get_chunk RPC
macula-relay: routes to Peer A
     ↓
Peer A: serve_file_content_rpc returns bytes
     ↓
Peer B: writes to content_store + inserts into briefcase_files ETS
     ↓
Peer B's Briefcase UI: new file appears 🎯
```

## Architectural decision captured (no true P2P)

Updates `plans/PLAN_BRIEFCASE.md` with a new "Transport Decision" section: **all mesh traffic transits macula-relay; direct peer-to-peer QUIC is not pursued.** Rationale + tradeoffs documented.

## New slices

| Slice | App | Role |
|---|---|---|
| `share_file_in_mesh` | guide_briefcase_lifecycle | Publishes `file_shared_v1` fact to `<realm>.briefcase.file_shared` |
| `serve_file_content_rpc` | guide_briefcase_lifecycle | Advertises & serves `<realm>.briefcase.get_chunk` |
| `listen_for_shared_files` | project_briefcase_files | Subscribes, fetches via RPC, projects |

## Domain events vs integration facts

Follows the CLAUDE.md rule:
- `file_uploaded_v1` is **local only** — stays in peer's event log
- `file_shared_v1` is an **integration fact** — separate schema, published to mesh
- No re-publish loop because subscriber writes directly to the read model, does NOT dispatch a local command

## Registration via `hecate_mesh_client`

Both the advertisement and subscription are registered at app boot via `hecate_mesh_client:register_advertisement/2` and `register_subscription/2`. These queue up and apply when the mesh activates — safe to call before relay connections are established.

## Idempotency

Subscriber checks `project_briefcase_files_store:get/1` before fetching content. If file already known locally, the fact is a no-op. Duplicate deliveries from the relay are harmless.

## Tradeoffs / non-goals

- **Whole-file fetch per fact.** No chunking yet. Big files = long first-byte latency. Phase 3 fixes this.
- **No retry queue.** If the source peer is offline, the fetch fails silently. Phase 3+.
- **No multi-peer fallback.** Only tries the originator. Phase 5.
- **No content signing verification beyond content_hash match.** Trust the relay for now. Phase 4.
- **No CRDT conflict resolution.** Last-writer-wins via ETS insert. OK for v1.

## Verified

- [x] `rebar3 compile` passes clean
- [x] `hecate_mesh_client:get_client` returns `{ok, pid()}` when activated, `{ok, undefined}` otherwise — handled explicitly
- [x] Subscriber runs in its own gen_server — heavy work (RPC + disk + ETS) off the mesh callback thread
- [x] No horizontal layers created; each slice has its own directory

## Test plan (after all 5 daemon PRs + web PR land)

1. Deploy hecate-daemon + hecate-web on 2 machines in the same realm
2. Upload a file on machine 1 via drag-and-drop
3. Observe it appear in machine 2's Briefcase → Realm Synced tab within seconds
4. Download from machine 2 — bytes match
5. Unplug machine 1 from network — file still openable on machine 2 (cached)
6. Large-file test: 100 MB file, time-to-visible on machine 2, verify hash match

## Next

- Chunking (Phase 3) — BLAKE3 1-MiB chunks, parallel fetch, resume
- E2E encryption (Phase 4) — per-realm key, per-file HKDF subkey
- UCAN sharing (Phase 5) — external share links, time-bounded grants
- Native sync folder reconciler (Phase 6) — the Dropbox UX over the same plumbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)