### PR TITLE
merge: briefcase stack (rescue stacked PRs #6–#9)

### DIFF
--- a/apps/guide_briefcase_lifecycle/src/briefcase_content_store.erl
+++ b/apps/guide_briefcase_lifecycle/src/briefcase_content_store.erl
@@ -1,0 +1,58 @@
+%%% @doc On-disk content store for Briefcase files.
+%%%
+%%% Phase 1: whole-file storage, content-addressed. Each file lives at:
+%%%     $HECATE_HOME/hecate-daemon/briefcase/content/{XX}/{FileId}.bin
+%%% where `XX` is the first 2 hex chars of the file_id (BLAKE3 hash) —
+%%% load-spreading over 256 sub-directories.
+%%%
+%%% Phase 3 replaces this with chunked storage:
+%%%     .../chunks/{XX}/{ChunkHash}.enc
+%%% and files become ordered sequences of chunk hashes.
+%%% @end
+-module(briefcase_content_store).
+
+-export([put/2, get/1, delete/1, exists/1]).
+-export([content_dir/0, content_path/1]).
+
+%% @doc Root directory for content storage.
+-spec content_dir() -> file:filename().
+content_dir() ->
+    Dir = filename:join(shared_paths:base_dir(), "briefcase/content"),
+    ok = filelib:ensure_path(Dir),
+    Dir.
+
+%% @doc Absolute on-disk path for a given file_id.
+-spec content_path(binary()) -> file:filename().
+content_path(FileId) when is_binary(FileId), byte_size(FileId) >= 2 ->
+    Prefix = binary:part(FileId, 0, 2),
+    SubDir = filename:join(content_dir(), binary_to_list(Prefix)),
+    ok = filelib:ensure_path(SubDir),
+    Name = <<FileId/binary, ".bin">>,
+    filename:join(SubDir, binary_to_list(Name)).
+
+%% @doc Write content bytes. Idempotent — same FileId overwrites.
+-spec put(binary(), binary()) -> ok | {error, term()}.
+put(FileId, Content) when is_binary(FileId), is_binary(Content) ->
+    Path = content_path(FileId),
+    file:write_file(Path, Content).
+
+%% @doc Read content bytes.
+-spec get(binary()) -> {ok, binary()} | {error, term()}.
+get(FileId) when is_binary(FileId) ->
+    Path = content_path(FileId),
+    file:read_file(Path).
+
+%% @doc Remove a file's content.
+-spec delete(binary()) -> ok | {error, term()}.
+delete(FileId) when is_binary(FileId) ->
+    Path = content_path(FileId),
+    case file:delete(Path) of
+        ok -> ok;
+        {error, enoent} -> ok;
+        {error, _} = E -> E
+    end.
+
+%% @doc Check if content is present locally.
+-spec exists(binary()) -> boolean().
+exists(FileId) when is_binary(FileId) ->
+    filelib:is_regular(content_path(FileId)).

--- a/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src
+++ b/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src
@@ -12,7 +12,8 @@
         macula,
         cowboy,
         shared,
-        hecate_api
+        hecate_api,
+        hecate_mesh
     ]},
     {env, []},
     {modules, []},

--- a/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src
+++ b/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle.app.src
@@ -8,7 +8,11 @@
         stdlib,
         reckon_db,
         evoq,
-        reckon_evoq
+        reckon_evoq,
+        macula,
+        cowboy,
+        shared,
+        hecate_api
     ]},
     {env, []},
     {modules, []},

--- a/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle_app.erl
+++ b/apps/guide_briefcase_lifecycle/src/guide_briefcase_lifecycle_app.erl
@@ -5,6 +5,10 @@
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
+    %% Register the mesh RPC advertisement for briefcase.get_chunk.
+    %% hecate_mesh_client queues it and applies when the mesh activates —
+    %% safe to call even before mesh is up.
+    ok = serve_file_content_rpc:register(),
     guide_briefcase_lifecycle_sup:start_link().
 
 stop(_State) ->

--- a/apps/guide_briefcase_lifecycle/src/serve_file_content_rpc/serve_file_content_rpc.erl
+++ b/apps/guide_briefcase_lifecycle/src/serve_file_content_rpc/serve_file_content_rpc.erl
@@ -1,0 +1,60 @@
+%%% @doc RPC handler: `<realm>.briefcase.get_chunk`.
+%%%
+%%% Serves content bytes from the local briefcase_content_store when
+%%% another peer in the realm requests them. Called from the mesh
+%%% subscriber flow on peers that do not yet have the content locally.
+%%%
+%%% Args (incoming call payload):
+%%%     #{ file_id => binary() }
+%%%
+%%% Reply:
+%%%     {ok, #{ file_id => binary(),
+%%%             size    => non_neg_integer(),
+%%%             bytes   => binary() }}
+%%%   | {error, not_available}
+%%%
+%%% Phase 2 serves whole files. Phase 3 replaces this with true chunk
+%%% fetches (keyed by content-addressed chunk hash).
+%%% @end
+-module(serve_file_content_rpc).
+
+-export([procedure/1, handle/1, register/0]).
+
+-spec procedure(binary()) -> binary().
+procedure(Realm) when is_binary(Realm) ->
+    <<Realm/binary, ".briefcase.get_chunk">>.
+
+%% @doc RPC handler. Signature matches macula:advertise expectations.
+-spec handle(map()) -> {ok, map()} | {error, term()}.
+handle(#{<<"file_id">> := FileId}) ->
+    handle_file_id(FileId);
+handle(#{file_id := FileId}) ->
+    handle_file_id(FileId);
+handle(_) ->
+    {error, missing_file_id}.
+
+handle_file_id(FileId) when is_binary(FileId) ->
+    case briefcase_content_store:get(FileId) of
+        {ok, Bytes} ->
+            {ok, #{
+                file_id => FileId,
+                size    => byte_size(Bytes),
+                bytes   => Bytes
+            }};
+        {error, enoent} ->
+            {error, not_available};
+        {error, Reason} ->
+            {error, Reason}
+    end;
+handle_file_id(_) ->
+    {error, invalid_file_id}.
+
+%% @doc Register the advertisement with the mesh client. Safe to call
+%% at boot — the subscription is queued until the mesh activates.
+-spec register() -> ok.
+register() ->
+    Realm = application:get_env(hecate, realm, <<"io.macula">>),
+    hecate_mesh_client:register_advertisement(
+        procedure(Realm),
+        fun ?MODULE:handle/1
+    ).

--- a/apps/guide_briefcase_lifecycle/src/share_file_in_mesh/share_file_in_mesh.erl
+++ b/apps/guide_briefcase_lifecycle/src/share_file_in_mesh/share_file_in_mesh.erl
@@ -1,0 +1,65 @@
+%%% @doc Publish a briefcase file as a mesh integration fact.
+%%%
+%%% Called after a successful local `upload_file_v1` dispatch. Publishes
+%%% `file_shared_v1` to the realm-scoped topic:
+%%%     `<realm>.briefcase.file_shared`
+%%%
+%%% Subscribers on other peers in the realm receive this fact and may
+%%% fetch the content via the `<realm>.briefcase.get_chunk` RPC.
+%%%
+%%% Integration fact schema (stable contract; distinct from internal
+%%% `file_uploaded_v1` domain event):
+%%%
+%%%     #{ event_type    => <<"file_shared_v1">>,
+%%%        file_id       => binary(),     %% BLAKE3 hex of content
+%%%        realm         => binary(),
+%%%        path          => binary(),
+%%%        mime_type     => binary(),
+%%%        size          => non_neg_integer(),
+%%%        content_hash  => binary(),
+%%%        author_did    => binary(),
+%%%        shared_at     => integer() }   %% wallclock ms
+%%%
+%%% Fire-and-forget on the caller's behalf — never blocks the command
+%%% dispatch path on mesh availability.
+%%% @end
+-module(share_file_in_mesh).
+
+-export([share/1, topic/1]).
+
+-spec share(map()) -> ok | {error, term()}.
+share(#{file_id := FileId, realm := Realm, path := Path,
+        mime_type := MimeType, size := Size, content_hash := Hash,
+        author_did := AuthorDid}) ->
+    Fact = #{
+        event_type    => <<"file_shared_v1">>,
+        file_id       => FileId,
+        realm         => Realm,
+        path          => Path,
+        mime_type     => MimeType,
+        size          => Size,
+        content_hash  => Hash,
+        author_did    => AuthorDid,
+        shared_at     => erlang:system_time(millisecond)
+    },
+    Topic = topic(Realm),
+    try hecate_mesh_client:publish(Topic, Fact) of
+        ok -> ok;
+        {error, Reason} ->
+            logger:warning("[briefcase] mesh publish failed for ~s: ~p",
+                           [FileId, Reason]),
+            {error, Reason};
+        Other ->
+            logger:warning("[briefcase] mesh publish unexpected: ~p", [Other]),
+            {error, Other}
+    catch Class:Error ->
+        logger:warning("[briefcase] mesh publish crashed: ~p:~p",
+                       [Class, Error]),
+        {error, {Class, Error}}
+    end;
+share(_Incomplete) ->
+    {error, missing_fields}.
+
+-spec topic(binary()) -> binary().
+topic(Realm) when is_binary(Realm) ->
+    <<Realm/binary, ".briefcase.file_shared">>.

--- a/apps/guide_briefcase_lifecycle/src/upload_file/maybe_upload_file.erl
+++ b/apps/guide_briefcase_lifecycle/src/upload_file/maybe_upload_file.erl
@@ -53,11 +53,21 @@ dispatch(Cmd) ->
         payload        = CmdMap#{command_type => upload_file},
         metadata       = #{timestamp => erlang:system_time(millisecond)}
     },
-    evoq_dispatcher:dispatch(EvoqCmd, #{
+    Result = evoq_dispatcher:dispatch(EvoqCmd, #{
         store_id    => briefcase_store,
         adapter     => reckon_evoq_adapter,
         consistency => eventual
-    }).
+    }),
+    case Result of
+        {ok, _Version, _Events} ->
+            %% Fire-and-forget publication of the integration fact to the
+            %% realm-scoped mesh topic. Local state is always authoritative;
+            %% mesh failures do not roll back the local upload.
+            _ = share_file_in_mesh:share(CmdMap),
+            Result;
+        _ ->
+            Result
+    end.
 
 %% Internal
 

--- a/apps/guide_briefcase_lifecycle/src/upload_file/upload_file_api.erl
+++ b/apps/guide_briefcase_lifecycle/src/upload_file/upload_file_api.erl
@@ -1,0 +1,101 @@
+%%% @doc Upload file API handler: POST /api/briefcase/files
+%%%
+%%% Accepts multipart/form-data with one `file` part (the binary content)
+%%% and optional form fields:
+%%%   - path:      logical path for the file (defaults to the upload filename)
+%%%   - mime_type: MIME override (defaults to the browser-supplied Content-Type)
+%%%
+%%% On success:
+%%%   - computes BLAKE3 of content → file_id + content_hash
+%%%   - writes content to briefcase_content_store
+%%%   - dispatches `upload_file_v1` command → emits `file_uploaded_v1`
+%%%
+%%% Response: 201 JSON `{ok: true, file_id, path, size}`.
+%%% @end
+-module(upload_file_api).
+
+-export([init/2, routes/0]).
+
+routes() -> [{"/api/briefcase/files/upload", ?MODULE, []}].
+
+init(Req0, State) ->
+    case cowboy_req:method(Req0) of
+        <<"POST">> -> handle_post(Req0, State);
+        _          -> hecate_api_utils:method_not_allowed(Req0)
+    end.
+
+handle_post(Req0, _State) ->
+    case read_multipart(Req0, #{}) of
+        {ok, #{file := Content} = Fields, Req1} ->
+            Filename  = maps:get(filename,  Fields, <<"untitled">>),
+            DefMime   = maps:get(mime_hint, Fields, <<"application/octet-stream">>),
+            Path      = maps:get(path,      Fields, Filename),
+            MimeType  = maps:get(mime_type, Fields, DefMime),
+            process_upload(Content, Path, MimeType, Req1);
+        {ok, _Fields, Req1} ->
+            hecate_api_utils:json_error(400, <<"Missing file part">>, Req1);
+        {error, Reason, Req1} ->
+            hecate_api_utils:json_error(400, Reason, Req1)
+    end.
+
+%%% ===================================================================
+%%% Internal
+%%% ===================================================================
+
+process_upload(Content, Path, MimeType, Req) ->
+    FileId = macula_blake3_nif:hash_hex(Content),
+    Size   = byte_size(Content),
+    case briefcase_content_store:put(FileId, Content) of
+        ok ->
+            dispatch_upload(FileId, Path, MimeType, Size, Req);
+        {error, Reason} ->
+            hecate_api_utils:json_error(500, {storage_error, Reason}, Req)
+    end.
+
+dispatch_upload(FileId, Path, MimeType, Size, Req) ->
+    Realm      = application:get_env(hecate, realm, <<"io.macula">>),
+    AuthorDid  = application:get_env(hecate, gateway_identity,
+                                     <<"mri:agent:io.macula/hecate">>),
+    UploadedAt = erlang:system_time(millisecond),
+    Cmd = upload_file_v1:new(FileId, Realm, to_bin(Path), to_bin(MimeType),
+                             Size, FileId, AuthorDid, UploadedAt),
+    case maybe_upload_file:dispatch(Cmd) of
+        {ok, _Version, _Events} ->
+            hecate_api_utils:json_ok(
+                #{file_id => FileId, path => to_bin(Path), size => Size},
+                Req);
+        {error, Reason} ->
+            %% Content was already written; remove it to keep disk clean.
+            _ = briefcase_content_store:delete(FileId),
+            hecate_api_utils:json_error(400, Reason, Req)
+    end.
+
+read_multipart(Req0, Acc) ->
+    case cowboy_req:read_part(Req0) of
+        {ok, Headers, Req1} ->
+            case cow_multipart:form_data(Headers) of
+                {data, FieldName} ->
+                    {ok, Body, Req2} = cowboy_req:read_part_body(Req1),
+                    read_multipart(Req2,
+                        Acc#{binary_to_atom(FieldName, utf8) => Body});
+                {file, _FieldName, Filename, ContentType} ->
+                    {ok, Body, Req2} = read_full_part_body(Req1, <<>>),
+                    read_multipart(Req2,
+                        Acc#{file      => Body,
+                             filename  => Filename,
+                             mime_hint => ContentType})
+            end;
+        {done, Req1} ->
+            {ok, Acc, Req1}
+    end.
+
+read_full_part_body(Req0, Acc) ->
+    case cowboy_req:read_part_body(Req0) of
+        {ok, Body, Req1} ->
+            {ok, <<Acc/binary, Body/binary>>, Req1};
+        {more, Body, Req1} ->
+            read_full_part_body(Req1, <<Acc/binary, Body/binary>>)
+    end.
+
+to_bin(B) when is_binary(B) -> B;
+to_bin(L) when is_list(L)   -> list_to_binary(L).

--- a/apps/hecate_api/src/hecate_api_routes.erl
+++ b/apps/hecate_api/src/hecate_api_routes.erl
@@ -27,6 +27,7 @@
     guide_plugin_lifecycle, project_plugins, query_plugins,
     guide_launcher_lifecycle, project_launcher, query_launcher,
     guide_mpong_game_lifecycle, project_mpong_games, query_mpong_games,
+    guide_briefcase_lifecycle, project_briefcase_files, query_briefcase_files,
     query_observer
 ]).
 

--- a/apps/project_briefcase_files/src/listen_for_shared_files/listen_for_shared_files.erl
+++ b/apps/project_briefcase_files/src/listen_for_shared_files/listen_for_shared_files.erl
@@ -1,0 +1,133 @@
+%%% @doc Mesh subscriber for `<realm>.briefcase.file_shared` facts.
+%%%
+%%% When another peer in the realm publishes a `file_shared_v1` fact,
+%%% this process:
+%%%   1. skips the fact if we already have the file locally
+%%%   2. fetches content via `<realm>.briefcase.get_chunk` RPC
+%%%   3. writes content to the local briefcase_content_store
+%%%   4. inserts the metadata into the briefcase_files ETS so the UI
+%%%      shows the new file immediately
+%%%
+%%% Phase 2 (this PR): whole-file fetch per fact, no retry queue.
+%%% Phase 3+: chunk-level parallel fetch, fallback to other peers,
+%%% signed-chunk verification, resume-on-reconnect.
+%%% @end
+-module(listen_for_shared_files).
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-define(RPC_TIMEOUT_MS, 30000).
+
+-record(state, {
+    realm   :: binary(),
+    topic   :: binary(),
+    rpc     :: binary()
+}).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    Realm = application:get_env(hecate, realm, <<"io.macula">>),
+    Topic = <<Realm/binary, ".briefcase.file_shared">>,
+    Rpc   = <<Realm/binary, ".briefcase.get_chunk">>,
+    Self  = self(),
+    Callback = fun(Fact) ->
+        Self ! {shared_fact, Fact},
+        ok
+    end,
+    hecate_mesh_client:register_subscription(Topic, Callback),
+    logger:info("[briefcase] subscribed to mesh topic ~s", [Topic]),
+    {ok, #state{realm = Realm, topic = Topic, rpc = Rpc}}.
+
+handle_call(_Req, _From, State) -> {reply, ok, State}.
+handle_cast(_Msg, State)        -> {noreply, State}.
+
+handle_info({shared_fact, Fact}, State) ->
+    _ = process_fact(Fact, State),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) -> ok.
+
+%%% ===================================================================
+%%% Internal
+%%% ===================================================================
+
+process_fact(Fact, State) ->
+    case extract_file_id(Fact) of
+        {ok, FileId} ->
+            case project_briefcase_files_store:get(FileId) of
+                {ok, _Entry} ->
+                    %% Already seen — idempotent re-delivery
+                    ok;
+                {error, not_found} ->
+                    fetch_and_store(FileId, Fact, State)
+            end;
+        {error, _} = E ->
+            logger:warning("[briefcase] malformed shared fact: ~p", [Fact]),
+            E
+    end.
+
+fetch_and_store(FileId, Fact, #state{rpc = Rpc}) ->
+    case hecate_mesh_client:get_client() of
+        {ok, Client} when is_pid(Client) ->
+            Args = #{file_id => FileId},
+            case macula:call(Client, Rpc, Args, ?RPC_TIMEOUT_MS) of
+                {ok, #{<<"bytes">> := Bytes} = _Reply} ->
+                    finalize(FileId, Bytes, Fact);
+                {ok, #{bytes := Bytes}} ->
+                    finalize(FileId, Bytes, Fact);
+                {ok, Other} ->
+                    logger:warning("[briefcase] unexpected RPC reply for ~s: ~p",
+                                   [FileId, Other]),
+                    {error, bad_reply};
+                {error, Reason} ->
+                    logger:warning("[briefcase] RPC ~s failed for ~s: ~p",
+                                   [Rpc, FileId, Reason]),
+                    {error, Reason}
+            end;
+        _ ->
+            logger:warning("[briefcase] mesh not activated; cannot fetch ~s",
+                           [FileId]),
+            {error, mesh_not_activated}
+    end.
+
+finalize(FileId, Bytes, Fact) ->
+    ok = briefcase_content_store:put(FileId, Bytes),
+    Entry = fact_to_entry(Fact),
+    ets:insert(briefcase_files, {FileId, Entry}),
+    logger:info("[briefcase] received shared file ~s (~b bytes)",
+                [FileId, byte_size(Bytes)]),
+    ok.
+
+%%% --- Helpers ------------------------------------------------------
+
+extract_file_id(#{<<"file_id">> := FileId}) when is_binary(FileId) -> {ok, FileId};
+extract_file_id(#{file_id     := FileId}) when is_binary(FileId) -> {ok, FileId};
+extract_file_id(_)                                               -> {error, no_file_id}.
+
+fact_to_entry(Fact) ->
+    #{
+        file_id      => gf(file_id, Fact),
+        realm        => gf(realm, Fact),
+        path         => gf(path, Fact),
+        mime_type    => gf(mime_type, Fact),
+        size         => gf(size, Fact),
+        content_hash => gf(content_hash, Fact),
+        author_did   => gf(author_did, Fact),
+        uploaded_at  => gf(shared_at, Fact),
+        status       => 1,
+        status_label => <<"Shared">>
+    }.
+
+gf(Key, Map) when is_atom(Key) ->
+    case maps:find(Key, Map) of
+        {ok, V} -> V;
+        error ->
+            BinKey = atom_to_binary(Key, utf8),
+            maps:get(BinKey, Map, undefined)
+    end.

--- a/apps/project_briefcase_files/src/project_briefcase_files.app.src
+++ b/apps/project_briefcase_files/src/project_briefcase_files.app.src
@@ -7,6 +7,8 @@
         kernel,
         stdlib,
         evoq,
+        macula,
+        hecate_mesh,
         guide_briefcase_lifecycle
     ]},
     {env, []},

--- a/apps/project_briefcase_files/src/project_briefcase_files_store.erl
+++ b/apps/project_briefcase_files/src/project_briefcase_files_store.erl
@@ -1,0 +1,69 @@
+%%% @doc Query facade for the briefcase_files ETS read model.
+%%%
+%%% Owns the public ETS table `briefcase_files`. Shared with
+%%% `briefcase_lifecycle_to_files` projection via `evoq_read_model_ets`
+%%% named-table support.
+%%%
+%%% Keys: file_id (binary). Values: map with
+%%% realm/path/mime_type/size/content_hash/author_did/uploaded_at/status.
+%%% @end
+-module(project_briefcase_files_store).
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([list/0, get/1, list_by_realm/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-define(TABLE, briefcase_files).
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%%====================================================================
+%% Query API (reads directly from public ETS)
+%%====================================================================
+
+-spec list() -> {ok, [map()]}.
+list() ->
+    try
+        {ok, [V || {_K, V} <- ets:tab2list(?TABLE)]}
+    catch
+        error:badarg -> {ok, []}
+    end.
+
+-spec get(binary()) -> {ok, map()} | {error, not_found}.
+get(FileId) when is_binary(FileId) ->
+    try
+        case ets:lookup(?TABLE, FileId) of
+            [{_, Entry}] -> {ok, Entry};
+            []           -> {error, not_found}
+        end
+    catch
+        error:badarg -> {error, not_found}
+    end.
+
+-spec list_by_realm(binary()) -> {ok, [map()]}.
+list_by_realm(Realm) when is_binary(Realm) ->
+    {ok, All} = ?MODULE:list(),
+    {ok, [E || #{realm := R} = E <- All, R =:= Realm]}.
+
+%%====================================================================
+%% gen_server callbacks — table lifecycle
+%%====================================================================
+
+init([]) ->
+    %% Create the public named table; projection writes via
+    %% evoq_read_model_ets with matching name.
+    case ets:info(?TABLE) of
+        undefined ->
+            ets:new(?TABLE, [named_table, public, set, {read_concurrency, true}]);
+        _ ->
+            ok
+    end,
+    {ok, #{}}.
+
+handle_call(_Req, _From, State) -> {reply, ok, State}.
+handle_cast(_Msg, State)        -> {noreply, State}.
+handle_info(_Info, State)       -> {noreply, State}.
+terminate(_Reason, _State)      -> ok.

--- a/apps/project_briefcase_files/src/project_briefcase_files_sup.erl
+++ b/apps/project_briefcase_files/src/project_briefcase_files_sup.erl
@@ -1,8 +1,9 @@
 %%% @doc Top-level supervisor for project_briefcase_files (PRJ).
 %%%
 %%% Starts the ETS store first (creates `briefcase_files` table), then
-%%% the merged projection that consumes briefcase lifecycle events from
-%%% the `briefcase_store` event log.
+%%% the merged projection consuming local briefcase lifecycle events,
+%%% then the mesh subscriber that catches `file_shared_v1` facts from
+%%% other peers in the realm.
 %%% @end
 -module(project_briefcase_files_sup).
 -behaviour(supervisor).
@@ -24,6 +25,12 @@ init([]) ->
           start   => {evoq_projection, start_link,
                       [briefcase_lifecycle_to_files, #{},
                        #{store_id => briefcase_store}]},
+          restart => permanent,
+          type    => worker},
+        %% Mesh subscriber: receives file_shared_v1 facts from peers and
+        %% fetches content via briefcase.get_chunk RPC.
+        #{id      => listen_for_shared_files,
+          start   => {listen_for_shared_files, start_link, []},
           restart => permanent,
           type    => worker}
     ],

--- a/apps/project_briefcase_files/src/project_briefcase_files_sup.erl
+++ b/apps/project_briefcase_files/src/project_briefcase_files_sup.erl
@@ -1,8 +1,8 @@
-%%% @doc Supervisor for project_briefcase_files.
+%%% @doc Top-level supervisor for project_briefcase_files (PRJ).
 %%%
-%%% Phase 1: no children yet — the projection is registered with evoq
-%%% at boot by `hecate_app`. Later phases may add a dedicated store
-%%% worker or read-model cache.
+%%% Starts the ETS store first (creates `briefcase_files` table), then
+%%% the merged projection that consumes briefcase lifecycle events from
+%%% the `briefcase_store` event log.
 %%% @end
 -module(project_briefcase_files_sup).
 -behaviour(supervisor).
@@ -13,10 +13,18 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    SupFlags = #{
-        strategy  => one_for_one,
-        intensity => 10,
-        period    => 10
-    },
-    Children = [],
-    {ok, {SupFlags, Children}}.
+    Children = [
+        %% ETS store (must start first — creates table)
+        #{id      => project_briefcase_files_store,
+          start   => {project_briefcase_files_store, start_link, []},
+          restart => permanent,
+          type    => worker},
+        %% Merged projection: briefcase lifecycle events -> files ETS
+        #{id      => briefcase_lifecycle_to_files,
+          start   => {evoq_projection, start_link,
+                      [briefcase_lifecycle_to_files, #{},
+                       #{store_id => briefcase_store}]},
+          restart => permanent,
+          type    => worker}
+    ],
+    {ok, {#{strategy => one_for_one, intensity => 10, period => 10}, Children}}.

--- a/apps/query_briefcase_files/src/get_file_by_id/get_file_by_id_api.erl
+++ b/apps/query_briefcase_files/src/get_file_by_id/get_file_by_id_api.erl
@@ -1,0 +1,24 @@
+%%% @doc API handler: GET /api/briefcase/files/:id
+%%%
+%%% Returns metadata for a single briefcase file.
+%%% @end
+-module(get_file_by_id_api).
+
+-export([init/2, routes/0]).
+
+routes() -> [{"/api/briefcase/files/:id", ?MODULE, []}].
+
+init(Req0, State) ->
+    case cowboy_req:method(Req0) of
+        <<"GET">> -> handle_get(Req0, State);
+        _         -> hecate_api_utils:method_not_allowed(Req0)
+    end.
+
+handle_get(Req0, _State) ->
+    FileId = cowboy_req:binding(id, Req0),
+    case project_briefcase_files_store:get(FileId) of
+        {ok, Entry} ->
+            hecate_api_utils:json_ok(Entry, Req0);
+        {error, not_found} ->
+            hecate_api_utils:json_error(404, <<"File not found">>, Req0)
+    end.

--- a/apps/query_briefcase_files/src/get_file_content/get_file_content_api.erl
+++ b/apps/query_briefcase_files/src/get_file_content/get_file_content_api.erl
@@ -1,0 +1,61 @@
+%%% @doc API handler: GET /api/briefcase/files/:id/content
+%%%
+%%% Streams raw bytes for a briefcase file. Content is served with
+%%% the Content-Type from the stored metadata, defaulting to
+%%% `application/octet-stream` when absent.
+%%%
+%%% NOTE: content_path duplicated from briefcase_content_store to keep
+%%% query_briefcase_files free of a cross-layer dep on
+%%% guide_briefcase_lifecycle. A follow-up PR may unify both into a
+%%% shared storage module once a second reader emerges (e.g. mesh
+%%% RPC handler `briefcase.get_chunk`).
+%%% @end
+-module(get_file_content_api).
+
+-export([init/2, routes/0]).
+
+routes() -> [{"/api/briefcase/files/:id/content", ?MODULE, []}].
+
+init(Req0, State) ->
+    case cowboy_req:method(Req0) of
+        <<"GET">> -> handle_get(Req0, State);
+        _         -> hecate_api_utils:method_not_allowed(Req0)
+    end.
+
+handle_get(Req0, _State) ->
+    FileId = cowboy_req:binding(id, Req0),
+    case project_briefcase_files_store:get(FileId) of
+        {ok, #{mime_type := MimeType}} ->
+            serve_content(FileId, MimeType, Req0);
+        {ok, _EntryWithoutMime} ->
+            serve_content(FileId, undefined, Req0);
+        {error, not_found} ->
+            hecate_api_utils:json_error(404, <<"File not found">>, Req0)
+    end.
+
+serve_content(FileId, MimeType, Req0) ->
+    case file:read_file(content_path(FileId)) of
+        {ok, Body} ->
+            Headers = #{
+                <<"content-type">>   => mime_or_default(MimeType),
+                <<"content-length">> => integer_to_binary(byte_size(Body))
+            },
+            cowboy_req:reply(200, Headers, Body, Req0);
+        {error, enoent} ->
+            hecate_api_utils:json_error(404,
+                <<"Content not locally available on this peer">>, Req0);
+        {error, Reason} ->
+            hecate_api_utils:json_error(500, Reason, Req0)
+    end.
+
+content_path(FileId) when is_binary(FileId), byte_size(FileId) >= 2 ->
+    Prefix = binary:part(FileId, 0, 2),
+    SubDir = filename:join(
+        [shared_paths:base_dir(), "briefcase/content",
+         binary_to_list(Prefix)]),
+    Name = <<FileId/binary, ".bin">>,
+    filename:join(SubDir, binary_to_list(Name)).
+
+mime_or_default(undefined) -> <<"application/octet-stream">>;
+mime_or_default(Mime) when is_binary(Mime) -> Mime;
+mime_or_default(Mime) when is_list(Mime) -> list_to_binary(Mime).

--- a/apps/query_briefcase_files/src/get_files_page/get_files_page_api.erl
+++ b/apps/query_briefcase_files/src/get_files_page/get_files_page_api.erl
@@ -21,19 +21,9 @@ init(Req0, State) ->
     end.
 
 handle_get(Req0, _State) ->
-    case list_active() of
+    case project_briefcase_files_store:list() of
         {ok, Files} ->
             hecate_api_utils:json_ok(#{items => Files}, Req0);
         {error, Reason} ->
             hecate_api_utils:json_error(500, Reason, Req0)
-    end.
-
-%% Phase 1: read directly from the briefcase_files ETS table.
-%% Phase 2+: add a dedicated store module (project_briefcase_files_store).
-list_active() ->
-    try
-        Entries = [V || {_K, V} <- ets:tab2list(briefcase_files)],
-        {ok, Entries}
-    catch
-        error:badarg -> {ok, []}
     end.

--- a/apps/query_briefcase_files/src/query_briefcase_files.app.src
+++ b/apps/query_briefcase_files/src/query_briefcase_files.app.src
@@ -6,6 +6,9 @@
     {applications, [
         kernel,
         stdlib,
+        cowboy,
+        shared,
+        hecate_api,
         project_briefcase_files
     ]},
     {env, []},

--- a/plans/PLAN_BRIEFCASE.md
+++ b/plans/PLAN_BRIEFCASE.md
@@ -41,6 +41,31 @@ Reasons:
 The prior `hecate-apps/hecate-app-briefcase` placeholder repo has been
 deleted (was empty scaffold; capability belongs inside the daemon).
 
+## Transport Decision — No True P2P (2026-04-20)
+
+**All mesh traffic transits macula-relay. We do not pursue direct
+peer-to-peer QUIC between nodes.**
+
+Why:
+
+- NAT traversal (ICE/STUN/TURN-equivalent over QUIC) is complex, unreliable
+  across hostile NATs, and demands session signalling we don't want to own.
+- Relay-mediated flow is simpler to debug, monitor, rate-limit, and bill.
+- The relay mesh itself is already global (`relay-{country}-{city}.macula.io`
+  — hundreds of nodes) and is part of our moat, not an afterthought.
+- UCAN authorization enforcement sits cleanly at the relay.
+
+Consequences for Briefcase:
+
+- `file_shared` pubsub facts flow A → relay → B.
+- `briefcase.get_chunk` RPC flows B → relay → A → relay → B.
+- Content bytes traverse relays for their entire path. Bandwidth is
+  the relay operator's concern; optimise via (a) chunking so first-byte
+  latency is low, (b) realm-locality — peers and relays in the same
+  geographic region, (c) caching hints.
+- No fallback to direct P2P. If relays are unreachable, Briefcase is
+  unreachable — this is an explicit tradeoff.
+
 ---
 
 ## Architecture

--- a/rebar.config
+++ b/rebar.config
@@ -126,6 +126,11 @@
         project_mpong_games,        %% PRJ: game state ETS projection
         query_mpong_games,          %% QRY: game API endpoints
 
+        %% Briefcase (mesh-backed file sharing — killer app)
+        guide_briefcase_lifecycle,  %% CMD: upload/revise/move/archive/purge/grant/revoke
+        project_briefcase_files,    %% PRJ: files ETS projection
+        query_briefcase_files,      %% QRY: file API endpoints
+
         %% Observer (BEAM diagnostics, read-only introspection)
         query_observer,
 

--- a/src/hecate_app.erl
+++ b/src/hecate_app.erl
@@ -41,7 +41,8 @@
     {payments_store,            "payments",            "Payments (payment process)"},
     {plugins_store,             "plugins",             "Plugins (install/upgrade/remove)"},
     {launcher_store,            "launcher",            "Launcher (sidebar layout lifecycle)"},
-    {mpong_store,               "mpong",               "MPong (mesh pong game lifecycle)"}
+    {mpong_store,               "mpong",               "MPong (mesh pong game lifecycle)"},
+    {briefcase_store,           "briefcase",           "Briefcase (file upload, revise, move, archive, grant)"}
 ]).
 
 %% Site store (cluster nodes, site-level state).


### PR DESCRIPTION
## Why this PR exists

PRs #5–#9 were stacked (each based on the prior branch, not main). When GitHub merged them, only **#5** (base=main) actually landed on main. PRs #6, #7, #8, #9 were merged into their parent feature branches, leaving the content orphaned — visible in the PRs as 'merged' but absent from main.

This is a known stacked-PR gotcha. GitHub doesn't auto-rebase children onto main after the first merge.

## What this PR lands

The 4 remaining PRs' content, in the same commits that were reviewed and merged into the orphan branches:

| From PR | Commit | Scope |
|---|---|---|
| #6 wiring | 54c0aac | Store + projection + route discovery |
| #7 upload | b7636a5 | POST upload + content store |
| #8 download | 37af63a | GET metadata + content |
| #9 mesh | 6bb1437 | Publish + subscribe + RPC — magic moment |
| (merge) | d5549e6 | Merge commit from PR #9 |

## After merge

- Main contains the full Briefcase stack (scaffold + wiring + upload + download + mesh)
- CI builds `:main` tag with Briefcase included
- Next `v*` tag will ship Briefcase to `:latest` manifest
- Orphan branches (feat/briefcase-scaffold, -wiring, -upload, -download, -mesh) can be deleted after this merges

No new content — same code that was already reviewed in #5–#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)