### PR TITLE
chore: release v0.18.0 (Briefcase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **Renamed pairing to joining** — all "pairing" terminology replaced with "joining
-  a realm". `hecate pair` CLI command is now `hecate join`. Confirm code removed —
-  OAuth login is sufficient proof of intent since the browser opens from the same
-  device. API endpoints changed from `/api/v1/pairing/sessions` to
-  `/api/v1/join/sessions`. `hecate_realm_session` state no longer carries
-  `confirm_code`.
-
 ### Ideas
 - **Settings history widget** — expose the settings event stream as a timeline
   on the settings page. A way to visualize our event-sourced nature: every
   initiation, realm joining, and preference change shown chronologically.
   Needs a new query desk (e.g. `get_settings_history/`) that reads from the
   settings ReckonDB stream and returns the event log.
+
+## [0.18.0] - 2026-04-20
+
+### Added
+- **Hecate Briefcase** — mesh-backed decentralized file sharing, the
+  killer app for the Macula mesh. Drop a file on one peer, it appears on
+  every other peer in the realm. Built-in to hecate-daemon via three new
+  apps following the CMD/PRJ/QRY trinity pattern:
+  - `guide_briefcase_lifecycle` (CMD) — `upload_file` command + slices
+    for future verbs (revise, move, archive, purge, grant, revoke);
+    aggregate + state + content store + mesh emitter + RPC handler
+  - `project_briefcase_files` (PRJ) — `briefcase_lifecycle_to_files`
+    projection + `briefcase_files` ETS read model + `listen_for_shared_files`
+    mesh subscriber that fetches content via realm-scoped RPC
+  - `query_briefcase_files` (QRY) — `GET /api/briefcase/files`,
+    `GET /api/briefcase/files/:id`, `GET /api/briefcase/files/:id/content`
+- **`POST /api/briefcase/files/upload`** — multipart upload endpoint.
+  Computes BLAKE3 of content (via `macula_blake3_nif`), writes to
+  `briefcase_content_store`, dispatches `upload_file_v1` → emits
+  `file_uploaded_v1`, projects to `briefcase_files` ETS, and fire-and-forget
+  publishes `file_shared_v1` integration fact to the realm mesh topic.
+- **Mesh distribution** — `<realm>.briefcase.file_shared` pubsub topic and
+  `<realm>.briefcase.get_chunk` RPC procedure, both realm-scoped. Subscribers
+  on other peers skip already-known files (idempotent), fetch content via RPC,
+  insert metadata into the local read model. All traffic transits
+  macula-relay; no direct peer-to-peer.
+- **`briefcase_store`** ReckonDB stream registered at `hecate_app` boot,
+  alongside the existing stores (settings, licenses, plugins, etc.).
+- **`plans/PLAN_BRIEFCASE.md`** — full phased roadmap with architectural
+  decisions (no-P2P, domain events vs integration facts, deferred
+  chunking/encryption/UCAN/sync-folder phases).
+
+### Changed
+- **Renamed pairing to joining** — all "pairing" terminology replaced with
+  "joining a realm". `hecate pair` CLI command is now `hecate join`.
+  Confirm code removed — OAuth login is sufficient proof of intent since
+  the browser opens from the same device. API endpoints changed from
+  `/api/v1/pairing/sessions` to `/api/v1/join/sessions`.
+  `hecate_realm_session` state no longer carries `confirm_code`.
+- Release version bumped 0.16.5 → 0.18.0. v0.17.0 was tagged at a
+  pre-Briefcase commit on 2026-03-27 and cannot be reused for this release.
 
 ## [0.11.2] - 2026-02-26
 

--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,7 @@
 
 %% Release configuration
 {relx, [
-    {release, {hecate, "0.16.5"}, [
+    {release, {hecate, "0.18.0"}, [
         %% Shared utilities (MUST start first - no hecate deps)
         shared,
 

--- a/src/hecate.app.src
+++ b/src/hecate.app.src
@@ -1,6 +1,6 @@
 {application, hecate,
  [{description, "Macula Hecate - Agent sidecar for mesh networking"},
-  {vsn, "0.16.6"},
+  {vsn, "0.18.0"},
   {registered, [hecate_sup, hecate_identity, hecate_mesh]},
   {mod, {hecate_app, []}},
   {applications,


### PR DESCRIPTION
## What

Version bump for the release that includes Briefcase.

| File | Change |
|---|---|
| `rebar.config` | `{release, {hecate, "0.16.5"}` → `"0.18.0"` |
| `src/hecate.app.src` | `{vsn, "0.16.6"}` → `"0.18.0"` |
| `CHANGELOG.md` | Move Unreleased content into new `[0.18.0] - 2026-04-20` section; add Briefcase Added entries |

## Why 0.18.0 and not 0.17.0

`v0.17.0` was tagged on 2026-03-27 at commit 91af522 — a pre-Briefcase point. The tag is already on the registry as a multi-arch manifest and cannot be reused. Jumping to 0.18.0 keeps SemVer monotonic.

## What ships

Everything merged since 0.16.5:

- Pairing → joining rename (CLI + API + session state)
- Briefcase: scaffold + wiring + upload + download + mesh (PRs #5–#10)
- `briefcase_store` at boot
- `<realm>.briefcase.file_shared` pubsub + `<realm>.briefcase.get_chunk` RPC
- 3 new apps (guide_briefcase_lifecycle, project_briefcase_files, query_briefcase_files)
- 1 new plan doc (`plans/PLAN_BRIEFCASE.md`)

## After merge

```bash
git tag v0.18.0
git push origin v0.18.0
```

CI (`.github/workflows/docker.yml`) builds `:0.18.0-amd64`, `:0.18.0-arm64`, then the manifest job creates multi-arch `:0.18.0`, `:latest`, and `:0.18` tags. hecate-install's `install.sh` (which now defaults to `:latest` since install#5) picks up Briefcase automatically.

## Follow-ups after the tag ships

1. Update `hecate-install/COMPATIBILITY.md` — add the 0.18.0 row and mark it as the first release with Briefcase
2. Smoke-test the drag-and-drop demo on two physical machines
3. Queue Phase 3 (chunking) as the next epic

## Verified

- [x] `rebar3 compile` passes clean on the bumped version
- [x] No other stale 0.16.x / 0.17.x references in the source tree (checked `src/`, `rebar.config`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)